### PR TITLE
Prevent crash

### DIFF
--- a/motorlib/propellant.py
+++ b/motorlib/propellant.py
@@ -5,9 +5,9 @@ class propellant(propertyCollection):
     def __init__(self):
         super().__init__()
         self.props['name'] = stringProperty('Name')
-        self.props['a'] = floatProperty('Burn rate Coefficient', 'm/(s*pa^n)', 0, 2)
+        self.props['a'] = floatProperty('Burn rate Coefficient', 'm/(s*Pa^n)', 0, 2)
         self.props['n'] = floatProperty('Burn rate Exponent', '', 0, 1)
         self.props['density'] = floatProperty('Density', 'kg/m^3', 0, 10000)
-        self.props['k'] = floatProperty('Specific Heat Ratio', '', 0, 10)
-        self.props['t'] = floatProperty('Combustion Temperature', 'k', 0, 10000)
+        self.props['k'] = floatProperty('Specific Heat Ratio', '', 1+1e-6, 10)
+        self.props['t'] = floatProperty('Combustion Temperature', 'K', 0, 10000)
         self.props['m'] = floatProperty('Exhaust Molar Mass', 'g/mol', 0, 100)


### PR DESCRIPTION
Setting k=1 would cause a divide by zero error and crash the program. Lower bound is now set to slightly higher than 1 to prevent the crash.