### PR TITLE
BurnSim handling and UI changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -284,6 +284,8 @@ class Window(QMainWindow):
     def addGrain(self):
         cm = self.fileManager.getCurrentMotor()
         newGrain = motorlib.grainTypes[self.ui.comboBoxGrainGeometry.currentText()]()
+        if len(cm.grains) != 0:
+            newGrain.setProperty('diameter', cm.grains[-1].getProperty('diameter'))
         cm.grains.append(newGrain)
         self.fileManager.addNewMotorHistory(cm)
         self.updateGrainTable()

--- a/main.py
+++ b/main.py
@@ -156,6 +156,7 @@ class Window(QMainWindow):
         self.ui.pushButtonMoveGrainUp.pressed.connect(lambda: self.moveGrain(-1))
         self.ui.pushButtonMoveGrainDown.pressed.connect(lambda: self.moveGrain(1))
         self.ui.pushButtonDeleteGrain.pressed.connect(self.deleteGrain)
+        self.ui.pushButtonCopyGrain.pressed.connect(self.copyGrain)
 
         self.ui.tableWidgetGrainList.itemSelectionChanged.connect(self.checkGrainSelection)
         self.checkGrainSelection()
@@ -208,6 +209,7 @@ class Window(QMainWindow):
             self.ui.tableWidgetGrainList.setEnabled(state)
         self.ui.pushButtonDeleteGrain.setEnabled(state)
         self.ui.pushButtonEditGrain.setEnabled(state)
+        self.ui.pushButtonCopyGrain.setEnabled(state)
         self.ui.pushButtonMoveGrainDown.setEnabled(state)
         self.ui.pushButtonMoveGrainUp.setEnabled(state)
 
@@ -227,10 +229,11 @@ class Window(QMainWindow):
                 self.ui.pushButtonMoveGrainUp.setEnabled(False)
             if gid == len(cm.grains) - 1: # Bottom grain selected
                 self.ui.pushButtonMoveGrainDown.setEnabled(False)
-            elif gid == len(cm.grains):
+            elif gid == len(cm.grains): # Nozzle selected
                 self.ui.pushButtonMoveGrainUp.setEnabled(False)
                 self.ui.pushButtonMoveGrainDown.setEnabled(False)
                 self.ui.pushButtonDeleteGrain.setEnabled(False)
+                self.ui.pushButtonCopyGrain.setEnabled(False)
         else:
             self.toggleGrainEditButtons(False, False)
 
@@ -255,6 +258,17 @@ class Window(QMainWindow):
             else:
                 self.ui.motorEditor.loadNozzle(cm.nozzle)
             self.toggleGrainButtons(False)
+
+    def copyGrain(self):
+        ind = self.ui.tableWidgetGrainList.selectionModel().selectedRows()
+        cm = self.fileManager.getCurrentMotor()
+        if len(ind) > 0:
+            gid = ind[0].row()
+            if gid < len(cm.grains):
+                cm.grains.append(cm.grains[gid])
+                self.fileManager.addNewMotorHistory(cm)
+                self.updateGrainTable()
+                self.checkGrainSelection()
 
     def deleteGrain(self):
         ind = self.ui.tableWidgetGrainList.selectionModel().selectedRows()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QWidget, QApplication, QMainWindow, QTableWidgetItem, QHeaderView, QMessageBox
+from PyQt5.QtWidgets import QWidget, QApplication, QMainWindow, QTableWidgetItem, QHeaderView, QMessageBox, QTableWidget
 from PyQt5.QtCore import pyqtSlot, pyqtSignal
 import sys
 import yaml
@@ -145,6 +145,7 @@ class Window(QMainWindow):
 
     def setupGrainTable(self):
         self.ui.tableWidgetGrainList.clearContents()
+        self.ui.tableWidgetGrainList.setEditTriggers(QTableWidget.NoEditTriggers)
 
         header = self.ui.tableWidgetGrainList.horizontalHeader()
         header.setSectionResizeMode(0, QHeaderView.ResizeToContents)

--- a/motorlib/grain.py
+++ b/motorlib/grain.py
@@ -114,7 +114,7 @@ class perforatedGrain(grain): # A grain with a hole of some shape through the ce
         uncored = geometry.circleArea(self.props['diameter'].getValue())
         return uncored - faceArea
 
-    def getMassFlux(self, massIn, dt, r, dr, position, density): # This duplicates a lot of code from bates. Time to make bates a perforated grain?
+    def getMassFlux(self, massIn, dt, r, dr, position, density):
         diameter = self.props['diameter'].getValue()
 
         bLength = self.getRegressedLength(r)

--- a/motorlib/propellant.py
+++ b/motorlib/propellant.py
@@ -11,3 +11,12 @@ class propellant(propertyCollection):
         self.props['k'] = floatProperty('Specific Heat Ratio', '', 1+1e-6, 10)
         self.props['t'] = floatProperty('Combustion Temperature', 'K', 0, 10000)
         self.props['m'] = floatProperty('Exhaust Molar Mass', 'g/mol', 1e-6, 100)
+
+    def getCStar(self):
+        k = self.props['k'].getValue()
+        t = self.props['t'].getValue()
+        m = self.props['m'].getValue()
+        r = 8314
+        num = (k * r/m * t)**0.5
+        denom = k * ((2/(k+1))**((k+1)/(k-1)))**0.5
+        return num / denom

--- a/uilib/__init__.py
+++ b/uilib/__init__.py
@@ -15,3 +15,4 @@ from .simulationManager import *
 from .aboutDialog import *
 from .tool import *
 from .toolManager import *
+from .burnsimManager import *

--- a/uilib/burnsimManager.py
+++ b/uilib/burnsimManager.py
@@ -142,8 +142,12 @@ class burnsimManager(QObject):
                         propellant.setProperty('a', motorlib.convert(a, 'in/(s*psi^n)', 'm/(s*Pa^n)')) # Conversion only does in/s to m/s, the rest is handled above
                         propellant.setProperty('density', motorlib.convert(float(impProp.attrib['Density']), 'lb/in^3', 'kg/m^3'))
                         propellant.setProperty('k', float(impProp.attrib['SpecificHeatRatio']))
-                        propellant.setProperty('m', 23.67) # BurnSim does't provide this value
-                        propellant.setProperty('t', 3500) # Or this one. TODO: modulate this to make the ISP correct
+                        impMolarMass = impProp.attrib['MolarMass']
+                        if impMolarMass == '0':
+                            propellant.setProperty('m', 23.67) # If the user has entered 0, override it to match the default propellant.
+                        else:
+                            propellant.setProperty('m', float(impMolarMass))
+                        propellant.setProperty('t', 3500) # Burnsim doesn't provide this property. Set it to match the default propellant.
                         motor.propellant = propellant
                         propSet = True
 

--- a/uilib/burnsimManager.py
+++ b/uilib/burnsimManager.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as ET
 
 import motorlib
 
+# BS type -> oM class for all grains we can import
 supportedGrainTable = {
                 '1': motorlib.grains.batesGrain,
                 '2': motorlib.grains.dGrain,
@@ -14,14 +15,44 @@ supportedGrainTable = {
                 '7': motorlib.grains.finocyl 
              }
 
+# BS type -> label for grains we know about but can't import
 unsupportedGrainTable = {
                 '4': 'Star',
                 '8': 'Tablet',
                 '9': 'Pie Segment'
             }
 
+# oM class -> BS type for grains we can export
+exportTypeTable = {
+                motorlib.grains.batesGrain: '1',
+                motorlib.grains.endBurner: '1',
+                motorlib.grains.dGrain: '2',
+                motorlib.grains.moonBurner: '3',
+                motorlib.grains.cGrain: '5',
+                motorlib.grains.xCore: '6',
+                motorlib.grains.finocyl: '7' 
+            }
+
+# Attributes for the root element of the BSX file
+bsxMotorAttrib = {
+                'Name': '',
+                'DiameterMM': '0',
+                'Length': '0',
+                'Delays': '0',
+                'HardwareWeight': '0',
+                'MFGCode': '',
+                'ThrustMethod': '1',
+                'ThrustCoefGiven': '1.2',
+                'UnitsLinear': '1'
+            }
+
+# Converts a string containing a value in inches to a float of meters
 def inToM(value):
     return motorlib.convert(float(value), 'in', 'm')
+
+# Converts a float containing meters to a string of inches
+def mToIn(value):
+    return str(motorlib.convert(value, 'm', 'in'))
 
 class burnsimManager(QObject):
     def __init__(self, fileManager):
@@ -36,13 +67,17 @@ class burnsimManager(QObject):
                 return self.importFile(path)
         return False
 
+    # Open a dialog to pick the file to save to and dump the BSX version of the current motor to it
     def showExportMenu(self):
         path = QFileDialog.getSaveFileName(None, 'Export BurnSim motor', '', 'BurnSim Motor Files (*.bsx)')[0]
         if path == '' or path is None:
             return
         if path[-4:] != '.bsx':
             path += '.bsx'
+        motor = self.fileManager.getCurrentMotor()
+        self.exportFile(path, motor)
 
+    # Show a dialog displaying some text
     def showWarning(self, text):
         msg = QMessageBox()
         msg.setText(text)
@@ -124,7 +159,85 @@ class burnsimManager(QObject):
         self.fileManager.startFromMotor(motor)
         return True
 
-    def exportFile(self):
-        pass
+    # Takes a path to a bsx file and motor object and dumps the BSX version of the motor to the file
+    def exportFile(self, path, motor):
+        errors = ''
 
+        outMotor = ET.Element('Motor')
+        outMotor.attrib = bsxMotorAttrib
 
+        outNozzle = ET.SubElement(outMotor, 'Nozzle')
+        outNozzle.attrib['ThroatDia'] = mToIn(motor.nozzle.getProperty('throat'))
+        outNozzle.attrib['ExitDia'] = mToIn(motor.nozzle.getProperty('exit'))
+        outNozzle.attrib['NozzleEfficiency'] = str(int(motor.nozzle.getProperty('efficiency') * 100))
+        outNozzle.attrib['AmbientPressure'] = '14.7'
+
+        for gid, grain in enumerate(motor.grains):
+            if type(grain) in exportTypeTable:
+                outGrain = ET.SubElement(outMotor, 'Grain')
+                outGrain.attrib['Type'] = exportTypeTable[type(grain)]
+                outGrain.attrib['Propellant'] = motor.propellant.getProperty('name')
+                outGrain.attrib['Diameter'] = mToIn(grain.getProperty('diameter'))
+                outGrain.attrib['Length'] = mToIn(grain.getProperty('length'))
+
+                if type(grain) is motorlib.grains.endBurner:
+                    outGrain.attrib['CoreDiameter'] = '0'
+                    outGrain.attrib['EndsInhibited'] = '1'
+                else:
+                    ends = grain.getProperty('inhibitedEnds')
+                    if ends == 'Neither':
+                        outGrain.attrib['EndsInhibited'] = '0'
+                    elif ends in ('Top', 'Bottom'):
+                        outGrain.attrib['EndsInhibited'] = '1'
+                    else:
+                        outGrain.attrib['EndsInhibited'] = '2'
+
+                    if type(grain) in (motorlib.grains.batesGrain, motorlib.grains.finocyl, motorlib.grains.moonBurner): # Grains with core diameter
+                        outGrain.attrib['CoreDiameter'] = mToIn(grain.getProperty('coreDiameter'))
+
+                    if type(grain) is motorlib.grains.dGrain:
+                        outGrain.attrib['EdgeOffset'] = mToIn(grain.getProperty('slotOffset'))
+
+                    elif type(grain) is motorlib.grains.moonBurner:
+                        outGrain.attrib['CoreOffset'] = mToIn(grain.getProperty('coreOffset'))
+
+                    elif type(grain) is motorlib.grains.cGrain:
+                        outGrain.attrib['SlotWidth'] = mToIn(grain.getProperty('slotWidth'))
+                        radius = motor.grains[-1].getProperty('diameter') / 2
+                        outGrain.attrib['SlotDepth'] = mToIn(grain.getProperty('slotOffset') - r)
+
+                    elif type(grain) is motorlib.grains.xCore:
+                        outGrain.attrib['SlotWidth'] = mToIn(grain.getProperty('slotWidth'))
+                        outGrain.attrib['CoreDiameter'] = mToIn(2 * grain.getProperty('slotLength'))
+
+                    elif type(grain) is motorlib.grains.finocyl:
+                        outGrain.attrib['FinCount'] = str(grain.getProperty('numFins'))
+                        outGrain.attrib['FinLength'] = mToIn(grain.getProperty('finLength'))
+                        outGrain.attrib['FinWidth'] = mToIn(grain.getProperty('finWidth'))
+
+                outProp = ET.SubElement(outGrain, 'Propellant')
+                outProp.attrib['Name'] = motor.propellant.getProperty('name')
+                a = motor.propellant.getProperty('a')
+                n = motor.propellant.getProperty('n')
+                a = motorlib.convert(a * (6895**n), 'm/(s*Pa^n)', 'in/(s*psi^n)')
+                outProp.attrib['BallisticA'] = str(a)
+                outProp.attrib['BallisticN'] = str(n)
+                outProp.attrib['Density'] = str(motorlib.convert(motor.propellant.getProperty('density'), 'kg/m^3', 'lb/in^3'))
+                outProp.attrib['SpecificHeatRatio'] = str(motor.propellant.getProperty('k'))
+                outProp.attrib['MolarMass'] = str(motor.propellant.getProperty('m'))
+                outProp.attrib['CombustionTemp'] = '0' # Unclear if this is used anyway
+                ispStar = motor.propellant.getCStar() / 9.80665
+                outProp.attrib['ISPStar'] = str(ispStar)
+
+                outNotes = ET.SubElement(outProp, 'Notes')
+
+            else:
+                errors += "Can't export grain #" + str(gid + 1) + " because it has type " + grain.geomName + ".\n"
+
+        outNotes = ET.SubElement(outMotor, 'MotorNotes')
+
+        if errors != '':
+            self.showWarning(errors + '\nThe rest of the motor will be exported.')
+
+        with open(path, 'wb') as outFile:
+            outFile.write(ET.tostring(outMotor))

--- a/uilib/burnsimManager.py
+++ b/uilib/burnsimManager.py
@@ -1,0 +1,130 @@
+from PyQt5.QtCore import QObject
+from PyQt5.QtWidgets import QFileDialog, QMessageBox
+
+import xml.etree.ElementTree as ET
+
+import motorlib
+
+supportedGrainTable = {
+                '1': motorlib.grains.batesGrain,
+                '2': motorlib.grains.dGrain,
+                '3': motorlib.grains.moonBurner,
+                '5': motorlib.grains.cGrain,
+                '6': motorlib.grains.xCore,
+                '7': motorlib.grains.finocyl 
+             }
+
+unsupportedGrainTable = {
+                '4': 'Star',
+                '8': 'Tablet',
+                '9': 'Pie Segment'
+            }
+
+def inToM(value):
+    return motorlib.convert(float(value), 'in', 'm')
+
+class burnsimManager(QObject):
+    def __init__(self, fileManager):
+        super().__init__()
+        self.fileManager = fileManager
+
+    # Open a dialog to pick the file to load and load it. Returns true if they load something, false otherwise
+    def showImportMenu(self):
+        if self.fileManager.unsavedCheck():
+            path = QFileDialog.getOpenFileName(None, 'Import BurnSim motor', '', 'BurnSim Motor Files (*.bsx)')[0]
+            if path != '' and path is not None:
+                return self.importFile(path)
+        return False
+
+    def showExportMenu(self):
+        path = QFileDialog.getSaveFileName(None, 'Export BurnSim motor', '', 'BurnSim Motor Files (*.bsx)')[0]
+        if path == '' or path is None:
+            return
+        if path[-4:] != '.bsx':
+            path += '.bsx'
+
+    def showWarning(self, text):
+        msg = QMessageBox()
+        msg.setText(text)
+        msg.setWindowTitle("Warning")
+        msg.exec_()
+
+    # Opens the BSX file located at path, generates a motor from it, and starts motor history there
+    def importFile(self, path):
+        motor = motorlib.motor()
+        tree = ET.parse(path)
+        root = tree.getroot()
+        errors = ''
+        propSet = False
+        for child in root:
+            if child.tag == 'Nozzle':
+                motor.nozzle.setProperty('throat', inToM(child.attrib['ThroatDia']))
+                motor.nozzle.setProperty('exit', inToM(child.attrib['ExitDia']))
+                motor.nozzle.setProperty('efficiency', float(child.attrib['NozzleEfficiency']) / 100)
+            if child.tag == 'Grain':
+                if child.attrib['Type'] in supportedGrainTable:
+                    motor.grains.append(supportedGrainTable[child.attrib['Type']]())
+                    motor.grains[-1].setProperty('diameter', inToM(child.attrib['Diameter']))
+                    motor.grains[-1].setProperty('length', inToM(child.attrib['Length']))
+
+                    grainType = child.attrib['Type']
+
+                    if child.attrib['EndsInhibited'] == '1':
+                        motor.grains[-1].setProperty('inhibitedEnds', 'Top')
+                    elif child.attrib['EndsInhibited'] == '2':
+                        motor.grains[-1].setProperty('inhibitedEnds', 'Both')
+
+                    if grainType in ('1', '3', '7'): # Grains with core diameter
+                        motor.grains[-1].setProperty('coreDiameter', inToM(child.attrib['CoreDiameter']))
+
+                    if grainType == '2': # D grain specific properties
+                        motor.grains[-1].setProperty('slotOffset', inToM(child.attrib['EdgeOffset']))
+
+                    elif grainType == '3': # Moonburner specific properties
+                        motor.grains[-1].setProperty('coreOffset', inToM(child.attrib['CoreOffset']))
+
+                    elif grainType == '5': # C grain specific properties
+                        motor.grains[-1].setProperty('slotWidth', inToM(child.attrib['SlotWidth']))
+                        radius = motor.grains[-1].getProperty('diameter') / 2
+                        motor.grains[-1].setProperty('slotOffset', radius - inToM(child.attrib['SlotDepth']))
+
+                    elif grainType == '6': # X core specific properties
+                        motor.grains[-1].setProperty('slotWidth', inToM(child.attrib['SlotWidth']))
+                        motor.grains[-1].setProperty('slotLength', inToM(child.attrib['CoreDiameter']) / 2)
+
+                    elif grainType == '7': # Finocyl specific properties
+                        motor.grains[-1].setProperty('finWidth', inToM(child.attrib['FinWidth']))
+                        motor.grains[-1].setProperty('finLength', inToM(child.attrib['FinLength']))
+                        motor.grains[-1].setProperty('numFins', int(child.attrib['FinCount']))
+
+                    if not propSet: # Use propellant numbers from the forward grain
+                        impProp = child.find('Propellant')
+                        propellant = motorlib.propellant()
+                        propellant.setProperty('name', impProp.attrib['Name'])
+                        n = float(impProp.attrib['BallisticN'])
+                        a = float(impProp.attrib['BallisticA']) * 1/(6895**n)
+                        propellant.setProperty('n', n)
+                        propellant.setProperty('a', motorlib.convert(a, 'in/(s*psi^n)', 'm/(s*Pa^n)')) # Conversion only does in/s to m/s, the rest is handled above
+                        propellant.setProperty('density', motorlib.convert(float(impProp.attrib['Density']), 'lb/in^3', 'kg/m^3'))
+                        propellant.setProperty('k', float(impProp.attrib['SpecificHeatRatio']))
+                        propellant.setProperty('m', 23.67) # BurnSim does't provide this value
+                        propellant.setProperty('t', 3500) # Or this one. TODO: modulate this to make the ISP correct
+                        motor.propellant = propellant
+                        propSet = True
+
+                else:
+                    if child.attrib['Type'] in unsupportedGrainTable:
+                        errors += "File contains a " + unsupportedGrainTable[child.attrib['Type']] + " grain, which can't be imported.\n"
+                    else:
+                        errors += "File contains an unknown grain of type " + child.attrib['Type'] + '.\n'
+        
+        if errors != '':
+            self.showWarning(errors + '\nThe rest of the motor will be imported.')
+
+        self.fileManager.startFromMotor(motor)
+        return True
+
+    def exportFile(self):
+        pass
+
+

--- a/uilib/collectionEditor.py
+++ b/uilib/collectionEditor.py
@@ -67,7 +67,9 @@ class collectionEditor(QWidget):
         for prop in object.props:
             self.propertyEditors[prop] = propertyEditor(self, object.props[prop], self.preferences)
             self.propertyEditors[prop].valueChanged.connect(self.propertyUpdate)
-            self.form.addRow(QLabel(object.props[prop].dispName + ':'), self.propertyEditors[prop])
+            label = QLabel(object.props[prop].dispName + ':')
+            label.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Expanding)
+            self.form.addRow(label, self.propertyEditors[prop])
         if self.buttons:
             self.applyButton.show()
             self.cancelButton.show()

--- a/uilib/views/forms/MainWindow.ui
+++ b/uilib/views/forms/MainWindow.ui
@@ -68,9 +68,15 @@
         </property>
         <item>
          <widget class="QComboBox" name="comboBoxPropellant">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="maximumSize">
            <size>
-            <width>200</width>
+            <width>250</width>
             <height>16777215</height>
            </size>
           </property>
@@ -79,7 +85,7 @@
         <item>
          <widget class="QPushButton" name="pushButtonPropEditor">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -92,7 +98,7 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>120</width>
+            <width>16777215</width>
             <height>16777215</height>
            </size>
           </property>
@@ -157,15 +163,27 @@
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QPushButton" name="pushButtonMoveGrainUp">
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
           <property name="text">
-           <string>Up</string>
+           <string>↑</string>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QPushButton" name="pushButtonMoveGrainDown">
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
           <property name="text">
-           <string>Down</string>
+           <string>↓</string>
           </property>
          </widget>
         </item>
@@ -173,6 +191,13 @@
          <widget class="QPushButton" name="pushButtonEditGrain">
           <property name="text">
            <string>Edit</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButtonCopyGrain">
+          <property name="text">
+           <string>Copy</string>
           </property>
          </widget>
         </item>
@@ -469,7 +494,7 @@
      <x>0</x>
      <y>0</y>
      <width>1300</width>
-     <height>21</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/uilib/views/forms/MainWindow.ui
+++ b/uilib/views/forms/MainWindow.ui
@@ -469,7 +469,7 @@
      <x>0</x>
      <y>0</y>
      <width>1300</width>
-     <height>24</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -484,14 +484,20 @@
      <addaction name="actionENGFile"/>
      <addaction name="actionImage"/>
      <addaction name="actionCSV"/>
-     <addaction name="actionBurnsimFile"/>
+     <addaction name="actionExportBurnSim"/>
+    </widget>
+    <widget class="QMenu" name="menuImport">
+     <property name="title">
+      <string>Import</string>
+     </property>
+     <addaction name="actionImportBurnSim"/>
     </widget>
     <addaction name="actionNew"/>
     <addaction name="actionOpen"/>
     <addaction name="actionSave"/>
     <addaction name="actionSaveAs"/>
     <addaction name="separator"/>
-    <addaction name="actionImport"/>
+    <addaction name="menuImport"/>
     <addaction name="menuExport"/>
     <addaction name="separator"/>
     <addaction name="actionQuit"/>
@@ -502,7 +508,6 @@
     </property>
     <addaction name="separator"/>
     <addaction name="actionRunSimulation"/>
-    <addaction name="actionGenerateReport"/>
    </widget>
    <widget class="QMenu" name="menuEdit">
     <property name="title">
@@ -666,14 +671,14 @@
     <string>Ctrl+Shift+S</string>
    </property>
   </action>
-  <action name="actionBurnsimFile">
+  <action name="actionExportBurnSim">
    <property name="text">
     <string>Burnsim File</string>
    </property>
   </action>
-  <action name="actionImport">
+  <action name="actionImportBurnSim">
    <property name="text">
-    <string>Import</string>
+    <string>BurnSim File</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This PR adds a BurnSim importer and exporter that handles all grain types that BS and oM have in common. It also adds a button to copy grains, a method for calculating c* to propellant objects, and a minor tweak to label spacing in collection editors that makes the UI more visually appealing.

Fixes issues #49, #45, and #10. 

I want to start getting code reviewed by other collaborators before I merge it into master. @tuxxi, would you be willing to look this over?