### PR TITLE
Trailoff fix and other simulation changes

### DIFF
--- a/motorlib/geometry.py
+++ b/motorlib/geometry.py
@@ -19,12 +19,14 @@ def cylinderArea(d, h):
 def cylinderVolume(d, h):
     return h * circleArea(d)
 
-def length(contour): # Adds up the length of each segment in a contour
+# Returns the total length of all segments in a contour that aren't within 'tolerance' of the edge of 'mapSize' diameter circle
+def length(contour, mapSize, tolerance = 3):
     offset = np.roll(contour.T, 1, axis = 1)
     l = np.linalg.norm(contour.T - offset, axis = 0)
-    return sum(list(l)[1:])
 
-def clean(contour, mapSize, tolerance): # Removes the points in a contour near the edge (inhibits the casting tube)
-    offset = np.array([[mapSize / 2, mapSize / 2]])
-    l = np.linalg.norm(contour - offset, axis = 1)
-    return contour[l < (mapSize / 2) - tolerance]
+    centerOffset = np.array([[mapSize / 2, mapSize / 2]])
+    radius = np.linalg.norm(contour - centerOffset, axis = 1)
+
+    valid = radius < (mapSize / 2) - tolerance
+
+    return np.sum(l[valid])

--- a/motorlib/geometry.py
+++ b/motorlib/geometry.py
@@ -30,3 +30,8 @@ def length(contour, mapSize, tolerance = 3):
     valid = radius < (mapSize / 2) - tolerance
 
     return np.sum(l[valid])
+
+def clean(contour, mapSize, tolerance): # Removes the points in a contour near the edge (inhibits the casting tube)
+    offset = np.array([[mapSize / 2, mapSize / 2]])
+    l = np.linalg.norm(contour - offset, axis = 1)
+    return contour[l < (mapSize / 2) - tolerance]

--- a/motorlib/grain.py
+++ b/motorlib/grain.py
@@ -240,7 +240,7 @@ class fmmGrain(perforatedGrain):
                 contourLengths[dist] = 0
                 layerContours = measure.find_contours(self.regressionMap, dist, fully_connected='low')
                 for contour in layerContours:
-                    contours[-1].append(contour)
+                    contours[-1].append(geometry.clean(contour, self.mapDim, 3))
                     contourLengths[dist] += geometry.length(contour, self.mapDim)
 
         except ValueError as e: # If there aren't any contours, do nothing

--- a/motorlib/grain.py
+++ b/motorlib/grain.py
@@ -197,10 +197,9 @@ class fmmGrain(perforatedGrain):
         mapDist = self.normalize(r)
 
         corePerimeter = 0
-        contours = measure.find_contours(self.regressionMap, mapDist, fully_connected='high')
+        contours = measure.find_contours(self.regressionMap, mapDist, fully_connected='low')
         for contour in contours:
-            contour = geometry.clean(contour, self.mapDim, 3)
-            corePerimeter += self.mapToLength(geometry.length(contour))
+            corePerimeter += self.mapToLength(geometry.length(contour, self.mapDim))
 
         return corePerimeter
 
@@ -239,13 +238,12 @@ class fmmGrain(perforatedGrain):
             for dist in np.linspace(0, regmax, numContours):
                 contours.append([])
                 contourLengths[dist] = 0
-                layerContours = measure.find_contours(self.regressionMap, dist, fully_connected='high')
+                layerContours = measure.find_contours(self.regressionMap, dist, fully_connected='low')
                 for contour in layerContours:
-                    cleaned = geometry.clean(contour, mapDim, 3)
-                    contours[-1].append(cleaned)
-                    contourLengths[dist] += geometry.length(cleaned)
+                    contours[-1].append(contour)
+                    contourLengths[dist] += geometry.length(contour, self.mapDim)
 
-        except ValueError: # If there aren't any contours, do nothing
-            pass
+        except ValueError as e: # If there aren't any contours, do nothing
+            print(e)
 
         return (masked, regressionMap, contours, contourLengths)

--- a/motorlib/grains/bates.py
+++ b/motorlib/grains/bates.py
@@ -68,9 +68,9 @@ class batesGrain(perforatedGrain):
                 layerContours = measure.find_contours(regressionMap, dist, fully_connected='high')
                 for contour in layerContours:
                     contours[-1].append(contour)
-                    contourLengths[dist] += geometry.length(contour)
+                    contourLengths[dist] += geometry.length(contour, mapDim)
 
-        except ValueError: # If there aren't any contours, do nothing
-            pass
+        except ValueError as e: # If there aren't any contours, do nothing
+            print(e)
 
         return (masked, regressionMap, contours, contourLengths)

--- a/motorlib/grains/finocyl.py
+++ b/motorlib/grains/finocyl.py
@@ -57,7 +57,7 @@ class finocyl(fmmGrain):
 
         if self.props['finWidth'].getValue() == 0:
             errors.append(simAlert(simAlertLevel.ERROR, simAlertType.GEOMETRY, 'Fin width must not be 0'))
-        if self.props['numFins'].getValue() != 0:
+        if self.props['numFins'].getValue() > 1:
             if 2 * (self.props['coreDiameter'].getValue() / 2 + self.props['finLength'].getValue()) * np.tan(np.pi / self.props['numFins'].getValue()) < self.props['finWidth'].getValue():
                 errors.append(simAlert(simAlertLevel.WARNING, simAlertType.GEOMETRY, 'Fin tips intersect'))
 

--- a/motorlib/motor.py
+++ b/motorlib/motor.py
@@ -179,14 +179,6 @@ class motor():
                 if callback(1 - progress): # If the callback returns true, it is time to cancel
                     return simRes
 
-        simRes.channels['time'].addData(simRes.channels['time'].getLast() + ts)
-        simRes.channels['kn'].addData(0)
-        simRes.channels['pressure'].addData(0)
-        simRes.channels['force'].addData(0)
-        simRes.channels['mass'].addData([grain.getVolumeAtRegression(0) * self.propellant.getProperty('density') for grain in self.grains])
-        simRes.channels['massFlow'].addData([0 for grain in self.grains])
-        simRes.channels['massFlux'].addData([0 for grain in self.grains])
-
         simRes.success = True
 
         return simRes

--- a/motorlib/nozzle.py
+++ b/motorlib/nozzle.py
@@ -28,7 +28,7 @@ class nozzle(propertyCollection):
         return geometry.circleArea(self.props['exit'].getValue())
 
     def getExitPressure(self, k, inputPressure):
-        return fsolve(lambda x: (1/self.calcExpansion()) - eRatioFromPRatio(k, x / inputPressure), 50000)[0]
+        return fsolve(lambda x: (1/self.calcExpansion()) - eRatioFromPRatio(k, x / inputPressure), 0)[0]
 
     def getGeometryErrors(self):
         errors = []

--- a/uilib/defaults.py
+++ b/uilib/defaults.py
@@ -23,7 +23,7 @@ def defaultMotor():
 def defaultPreferences():
     pref = preferences()
 
-    pref.general.props['burnoutWebThres'].setValue(0.03 / 39.37)
+    pref.general.props['burnoutWebThres'].setValue(0.01 / 39.37)
     pref.general.props['burnoutThrustThres'].setValue(0.1)
     pref.general.props['timestep'].setValue(0.03)
     pref.general.props['ambPressure'].setValue(101325)


### PR DESCRIPTION
This PR addresses the issue in #30 where KN would change rapidly near the shutdown of FMM grains. The issue stemmed from how contour lengths were being calculated. Points in contours near the casting tube were removed from the contour to simulate the inhibition of these surfaces. The length of the contour was then calculated over all but the last segment to exclude the 'jump' in open contours that touch the edge. This method was far from perfect, because in addition to excluding a (probably negligible) amount of area from every grain, there were occasional situations when the discontinuity wasn't the last segment in the contour. This seemed to happen almost at random, and the inclusion of these long segments led to the amount of surface area jumping around near shutdown. The fix was to merge the `clean` method into length calculation. The length of every segment in the contour is calculated, but only the segments with both ends far enough from the edge are included in the sum that is returned. The clean method is left behind for use in the grain preview widget.

A second source of these spikes that only effected thrust calculation was the exit pressure function solver, which seemed to perform badly at low pressure. Changing the initial guess to 0 pa fixed the issue. Reducing the grain burnout threshold cleared up the last step near shutdown. A final simulation related issue was that an extra 0 point was being appended on to the end of each simulation, which was removed. 

@tuxxi it should take less time to look over the code changes than it will to read that paragraph.