### PR TITLE
Default motor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Current Features:
 * A propellant editor that allows the user to enter the properties of as many propellants as they wish
 * The grain editor displays how a grain will regress to cut down on the guesswork involved in tweaking geometry
 * ENG file exporting
+* Burnsim importing and exporting
 * A UI that supports saving and loading designs along with undo and redo.
 
 Planned Features:
 * Erosivity simulation
 * Loading custom grain geometry from SVG files
-* Burnsim importing and exporting
 * Detailed output of every calculated parameter at any time and position along the motor
 
 The calculations involved were sourced from Rocket Propulsion Elements by George Sutton and from Richard Nakka's website (https://www.nakka-rocketry.net/rtheory.html).
@@ -54,7 +54,7 @@ Once everything is set up, you can start openMotor by running: `python main.py`
 
 License
 -------
-openMotor is released under the GNU GPL v3 license. The source code is distributed so you don't have to trust the calculations are being done correctly and can check for yourself if you doubt the results.
+openMotor is released under the GNU GPL v3 license. The source code is distributed so you can build cool stuff with it, and so you don't have to trust the calculations are being done correctly and can check for yourself if you doubt the results.
 
 Contributing
 ------------

--- a/motorlib/grains/finocyl.py
+++ b/motorlib/grains/finocyl.py
@@ -39,7 +39,7 @@ class finocyl(fmmGrain):
 
     def getDetailsString(self, preferences):
         lengthUnit = preferences.units.getProperty('m')
-        return 'Core: ' + self.props['coreDiameter'].dispFormat(lengthUnit) + ', Fins: ' + str(self.props['numFins'].getValue())
+        return 'Length: ' + self.props['length'].dispFormat(lengthUnit) + ', Core: ' + self.props['coreDiameter'].dispFormat(lengthUnit) + ', Fins: ' + str(self.props['numFins'].getValue())
 
     def getGeometryErrors(self):
         errors = super().getGeometryErrors()

--- a/motorlib/nozzle.py
+++ b/motorlib/nozzle.py
@@ -36,4 +36,6 @@ class nozzle(propertyCollection):
             errors.append(simAlert(simAlertLevel.ERROR, simAlertType.GEOMETRY, 'Throat diameter must not be 0', 'Nozzle'))
         if self.props['exit'].getValue() < self.props['throat'].getValue():
             errors.append(simAlert(simAlertLevel.ERROR, simAlertType.GEOMETRY, 'Exit diameter must not be smaller than throat diameter', 'Nozzle'))
+        if self.props['efficiency'].getValue() == 0:
+            errors.append(simAlert(simAlertLevel.ERROR, simAlertType.CONSTRAINT, 'Efficiency should not be 0', 'Nozzle'))
         return errors

--- a/motorlib/nozzle.py
+++ b/motorlib/nozzle.py
@@ -37,5 +37,5 @@ class nozzle(propertyCollection):
         if self.props['exit'].getValue() < self.props['throat'].getValue():
             errors.append(simAlert(simAlertLevel.ERROR, simAlertType.GEOMETRY, 'Exit diameter must not be smaller than throat diameter', 'Nozzle'))
         if self.props['efficiency'].getValue() == 0:
-            errors.append(simAlert(simAlertLevel.ERROR, simAlertType.CONSTRAINT, 'Efficiency should not be 0', 'Nozzle'))
+            errors.append(simAlert(simAlertLevel.ERROR, simAlertType.CONSTRAINT, 'Efficiency most not be 0', 'Nozzle'))
         return errors

--- a/motorlib/nozzle.py
+++ b/motorlib/nozzle.py
@@ -37,5 +37,5 @@ class nozzle(propertyCollection):
         if self.props['exit'].getValue() < self.props['throat'].getValue():
             errors.append(simAlert(simAlertLevel.ERROR, simAlertType.GEOMETRY, 'Exit diameter must not be smaller than throat diameter', 'Nozzle'))
         if self.props['efficiency'].getValue() == 0:
-            errors.append(simAlert(simAlertLevel.ERROR, simAlertType.CONSTRAINT, 'Efficiency most not be 0', 'Nozzle'))
+            errors.append(simAlert(simAlertLevel.ERROR, simAlertType.CONSTRAINT, 'Efficiency must not be 0', 'Nozzle'))
         return errors

--- a/motorlib/propellant.py
+++ b/motorlib/propellant.py
@@ -2,7 +2,7 @@ from . import units
 from .properties import *
 
 class propellant(propertyCollection):
-    def __init__(self):
+    def __init__(self, propDict = None):
         super().__init__()
         self.props['name'] = stringProperty('Name')
         self.props['a'] = floatProperty('Burn rate Coefficient', 'm/(s*Pa^n)', 0, 2)
@@ -11,6 +11,9 @@ class propellant(propertyCollection):
         self.props['k'] = floatProperty('Specific Heat Ratio', '', 1+1e-6, 10)
         self.props['t'] = floatProperty('Combustion Temperature', 'K', 0, 10000)
         self.props['m'] = floatProperty('Exhaust Molar Mass', 'g/mol', 1e-6, 100)
+
+        if propDict is not None:
+            self.setProperties(propDict)
 
     def getCStar(self):
         k = self.props['k'].getValue()

--- a/motorlib/properties.py
+++ b/motorlib/properties.py
@@ -28,7 +28,7 @@ class floatProperty(property):
             super().setValue(value)
 
     def dispFormat(self, unit):
-        return str(round(units.convert(self.value, self.unit, unit), 3)) + ' ' + unit
+        return str(round(units.convert(self.value, self.unit, unit), 6)) + ' ' + unit
 
 class enumProperty(property):
     def __init__(self, dispName, values):

--- a/uilib/burnsimManager.py
+++ b/uilib/burnsimManager.py
@@ -156,7 +156,10 @@ class burnsimManager(QObject):
                         errors += "File contains a " + unsupportedGrainTable[child.attrib['Type']] + " grain, which can't be imported.\n"
                     else:
                         errors += "File contains an unknown grain of type " + child.attrib['Type'] + '.\n'
-        
+
+            if child.tag == 'TestData':
+                errors += "\nFile contains test data, which is not imported."
+
         if errors != '':
             self.showWarning(errors + '\nThe rest of the motor will be imported.')
 

--- a/uilib/fileManager.py
+++ b/uilib/fileManager.py
@@ -23,7 +23,7 @@ class fileManager(QObject):
     # Check if current motor has unsaved changes and start over from default motor. Called when the menu item is triggered.
     def newFile(self):
         if self.unsavedCheck():
-            self.startFromMotor(defaults.defaultMotor())
+            self.startFromMotor(motorlib.motor())
 
     # Reset to empty motor history and set current motor to what is passed in
     def startFromMotor(self, motor, filename = None):
@@ -62,7 +62,7 @@ class fileManager(QObject):
                     res = loadFile(path, fileTypes.MOTOR)
                     if res is not None:
                         motor = motorlib.motor()
-                        motor.loadDict(res)
+                        motor.applyDict(res)
                         self.startFromMotor(motor, path)
                         return True
                 except Exception as e:
@@ -81,7 +81,7 @@ class fileManager(QObject):
     # Return the recent end of the motor history
     def getCurrentMotor(self):
         nm = motorlib.motor()
-        nm.loadDict(self.fileHistory[self.currentVersion])
+        nm.applyDict(self.fileHistory[self.currentVersion])
         return nm
 
     # Add a new entry to motor history

--- a/uilib/preferences.py
+++ b/uilib/preferences.py
@@ -5,7 +5,7 @@ from motorlib import propertyCollection, floatProperty, intProperty, enumPropert
 from motorlib import unitLabels, getAllConversions
 
 class preferences():
-    def __init__(self):
+    def __init__(self, propDict = None):
         self.general = propertyCollection()
         self.general.props['burnoutWebThres'] = floatProperty('Web Burnout Threshold', 'm', 2.54e-5, 3.175e-3)
         self.general.props['burnoutThrustThres'] = floatProperty('Thrust Burnout Threshold', '%', 0.01, 10)
@@ -15,6 +15,9 @@ class preferences():
         self.units = propertyCollection()
         for unit in unitLabels:
             self.units.props[unit] = enumProperty(unitLabels[unit], getAllConversions(unit))
+
+        if propDict is not None:
+            self.applyDict(dictionary)
 
     def getDict(self):
         prefDict = {}


### PR DESCRIPTION
Addresses #39 and #63.

This PR gives the prop selector a new '-' option for when the motor has `None` as its propellant. Motors have also been updated to support this, which involved a few changes that felt a bit hacky. The end result is worth it though, because the program now starts to an empty motor and the user is allowed to delete all of their propellants if they choose. The old constraint where a motor had to have a propellant meant that the library had to contain at least one propellant, which led to some annoying behavior. This commit also changes the number of digits displayed in the motor table and adds more output to burnsim importing.

@tuxxi