### PR TITLE
Custom grains

### DIFF
--- a/motorlib/geometry.py
+++ b/motorlib/geometry.py
@@ -35,3 +35,6 @@ def clean(contour, mapSize, tolerance): # Removes the points in a contour near t
     offset = np.array([[mapSize / 2, mapSize / 2]])
     l = np.linalg.norm(contour - offset, axis = 1)
     return contour[l < (mapSize / 2) - tolerance]
+
+def dist(p1, p2):
+    return ((p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2) ** 0.5

--- a/motorlib/grains/__init__.py
+++ b/motorlib/grains/__init__.py
@@ -6,9 +6,10 @@ from .star import *
 from .xCore import *
 from .cGrain import *
 from .dGrain import *
+from .custom import *
 
 # Generate grain geometry name -> constructor lookup table
 grainTypes = {}
-grainClasses = [batesGrain, endBurningGrain, finocyl, moonBurner, starGrain, xCore, cGrain, dGrain]
+grainClasses = [batesGrain, endBurningGrain, finocyl, moonBurner, starGrain, xCore, cGrain, dGrain, CustomGrain]
 for grainType in grainClasses:
     grainTypes[grainType.geomName] = grainType

--- a/motorlib/grains/custom.py
+++ b/motorlib/grains/custom.py
@@ -1,6 +1,7 @@
 from .. import fmmGrain
 from ..properties import *
 from .. import simAlert, simAlertLevel, simAlertType
+from ..units import getAllConversions, convert
 
 import numpy as np
 import skimage.draw as draw
@@ -10,11 +11,13 @@ class CustomGrain(fmmGrain):
     def __init__(self):
         super().__init__()
         self.props['points'] = polygonProperty('Core geometry')
+        self.props['dxfUnit'] = enumProperty('DXF Unit', getAllConversions('m'))
 
     def generateCoreMap(self):
+        inUnit = self.props['dxfUnit'].getValue()
         for polygon in self.props['points'].getValue():
-            r = [(self.mapDim - (self.normalize(p[1]) * (self.mapDim / 2))) / 2 for p in polygon]
-            c = [(self.mapDim / 2) + (self.normalize(p[0]) * (self.mapDim / 2)) / 2 for p in polygon]
+            r = [(self.mapDim / 2) + (-self.normalize(convert(p[1], inUnit, 'm')) * (self.mapDim / 2)) for p in polygon]
+            c = [(self.mapDim / 2) + (self.normalize(convert(p[0], inUnit, 'm')) * (self.mapDim / 2)) for p in polygon]
             rr, cc = draw.polygon(r, c)
             self.coreMap[rr, cc] = 0
 

--- a/motorlib/grains/custom.py
+++ b/motorlib/grains/custom.py
@@ -1,0 +1,27 @@
+from .. import fmmGrain
+from ..properties import *
+from .. import simAlert, simAlertLevel, simAlertType
+
+import numpy as np
+import skimage.draw as draw
+
+class CustomGrain(fmmGrain):
+    geomName = 'Custom Grain'
+    def __init__(self):
+        super().__init__()
+        self.props['points'] = polygonProperty('Core geometry')
+
+    def generateCoreMap(self):
+        for polygon in self.props['points'].getValue():
+            r = [self.mapDim - (self.normalize(p[1])  * (self.mapDim / 2)) for p in polygon]
+            c = [self.normalize(p[0]) * (self.mapDim / 2) for p in polygon]
+            rr, cc = draw.polygon(r, c)
+            self.coreMap[rr, cc] = 0
+
+    def getGeometryErrors(self):
+        errors = super().getGeometryErrors()
+
+        if len(self.props['points'].getValue()) > 1:
+            errors.append(simAlert(simAlertLevel.WARNING, simAlertType.GEOMETRY, 'Support for custom grains with multiple cores is experimental'))
+
+        return errors

--- a/motorlib/grains/custom.py
+++ b/motorlib/grains/custom.py
@@ -13,8 +13,8 @@ class CustomGrain(fmmGrain):
 
     def generateCoreMap(self):
         for polygon in self.props['points'].getValue():
-            r = [self.mapDim - (self.normalize(p[1])  * (self.mapDim / 2)) for p in polygon]
-            c = [self.normalize(p[0]) * (self.mapDim / 2) for p in polygon]
+            r = [(self.mapDim - (self.normalize(p[1]) * (self.mapDim / 2))) / 2 for p in polygon]
+            c = [(self.mapDim / 2) + (self.normalize(p[0]) * (self.mapDim / 2)) / 2 for p in polygon]
             rr, cc = draw.polygon(r, c)
             self.coreMap[rr, cc] = 0
 

--- a/motorlib/grains/custom.py
+++ b/motorlib/grains/custom.py
@@ -18,7 +18,7 @@ class CustomGrain(fmmGrain):
         for polygon in self.props['points'].getValue():
             r = [(self.mapDim / 2) + (-self.normalize(convert(p[1], inUnit, 'm')) * (self.mapDim / 2)) for p in polygon]
             c = [(self.mapDim / 2) + (self.normalize(convert(p[0], inUnit, 'm')) * (self.mapDim / 2)) for p in polygon]
-            rr, cc = draw.polygon(r, c)
+            rr, cc = draw.polygon(r, c, self.coreMap.shape)
             self.coreMap[rr, cc] = 0
 
     def getGeometryErrors(self):

--- a/motorlib/properties.py
+++ b/motorlib/properties.py
@@ -58,6 +58,11 @@ class stringProperty(property):
     def __init__(self, dispName):
         super().__init__(dispName, '', str)
 
+class polygonProperty(property):
+    def __init__(self, dispName):
+        super().__init__(dispName, '', list)
+        self.value = []
+
 class propertyCollection():
     def __init__(self):
         self.props = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ appdirs==1.4.3
 cycler==0.10.0
 decorator==4.4.0
 docopt==0.6.2
+ezdxf==0.9
 imageio==2.5.0
 kiwisolver==1.0.1
 matplotlib==3.0.3

--- a/uilib/__init__.py
+++ b/uilib/__init__.py
@@ -1,6 +1,7 @@
 from .fileIO import saveFile, loadFile, fileTypes, appVersion, getConfigPath
 from .graphWidget import *
 from .grainPreviewWidget import grainPreviewGraph, grainPreviewWidget
+from .polygonEditor import *
 from .propertyEditor import *
 from .collectionEditor import *
 from .motorEditor import *

--- a/uilib/grainPreviewWidget.py
+++ b/uilib/grainPreviewWidget.py
@@ -103,7 +103,7 @@ class grainPreviewWidget(QWidget):
         dataThread.start()
 
     def _genData(self, grain):
-        out = grain.getRegressionData(200)
+        out = grain.getRegressionData(250)
         self.previewReady.emit(out)
 
     def updateView(self, data):

--- a/uilib/polygonEditor.py
+++ b/uilib/polygonEditor.py
@@ -2,6 +2,7 @@ from PyQt5.QtWidgets import QWidget, QPushButton, QHBoxLayout, QFileDialog
 from PyQt5.QtCore import pyqtSignal
 
 import ezdxf
+import math
 import motorlib
 
 class PolygonEditor(QWidget):
@@ -37,5 +38,29 @@ class PolygonEditor(QWidget):
             for lwpl in msp.query('LWPOLYLINE'):
                 with lwpl.points() as points:
                     self.points.append([(motorlib.convert(p[0], inUnit, 'm'), motorlib.convert(p[1], inUnit, 'm')) for p in points])
+
+            p = []
+
+            for ent in msp:
+                if ent.dxftype() == 'ARC':
+                    part = []
+                    sa = ent.dxf.start_angle
+                    ea = ent.dxf.end_angle
+                    if sa > ea:
+                        ea += 360
+                    for i in range(0, 10):
+                        a = sa + ((ea - sa) * (i / 9))
+                        px = ent.dxf.center[0] + (math.cos(a * 3.14159 / 180) * ent.dxf.radius)
+                        py = ent.dxf.center[1] + (math.sin(a * 3.14159 / 180) * ent.dxf.radius)
+                        part.append((motorlib.convert(px, inUnit, 'm'), motorlib.convert(py, inUnit, 'm')))
+                    if motorlib.dist(part[-1], p[-1]) < motorlib.dist(part[0], p[-1]):
+                        part.reverse()
+                    p += part
+
+                if ent.dxftype() == 'LINE':
+                    p.append((motorlib.convert(ent.dxf.end[0], inUnit, 'm'), motorlib.convert(ent.dxf.end[1], inUnit, 'm')))
+                    p.append((motorlib.convert(ent.dxf.start[0], inUnit, 'm'), motorlib.convert(ent.dxf.start[1], inUnit, 'm')))
+
+            self.points.append(p)
 
             self.pointsChanged.emit()

--- a/uilib/polygonEditor.py
+++ b/uilib/polygonEditor.py
@@ -2,6 +2,7 @@ from PyQt5.QtWidgets import QWidget, QPushButton, QHBoxLayout, QFileDialog
 from PyQt5.QtCore import pyqtSignal
 
 import ezdxf
+import motorlib
 
 class PolygonEditor(QWidget):
 
@@ -17,6 +18,8 @@ class PolygonEditor(QWidget):
 
         self.points = []
 
+        self.preferences = None
+
     def loadDXF(self, path = None):
         if path is None:
             path = QFileDialog.getOpenFileName(None, 'Load core geometry', '', 'DXF Files (*.dxf)')[0]
@@ -26,8 +29,13 @@ class PolygonEditor(QWidget):
 
             self.points = []
 
+            if self.preferences is None:
+                inUnit = 'in'
+            else:
+                inUnit = self.preferences.getUnit('m')
+
             for lwpl in msp.query('LWPOLYLINE'):
                 with lwpl.points() as points:
-                    self.points.append([(p[0] / 39.37, p[1] / 39.37) for p in points])
+                    self.points.append([(motorlib.convert(p[0], inUnit, 'm'), motorlib.convert(p[1], inUnit, 'm')) for p in points])
 
             self.pointsChanged.emit()

--- a/uilib/polygonEditor.py
+++ b/uilib/polygonEditor.py
@@ -1,0 +1,33 @@
+from PyQt5.QtWidgets import QWidget, QPushButton, QHBoxLayout, QFileDialog
+from PyQt5.QtCore import pyqtSignal
+
+import ezdxf
+
+class PolygonEditor(QWidget):
+
+    pointsChanged = pyqtSignal()
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.setLayout(QHBoxLayout())
+
+        self.selectButton = QPushButton('Select')
+        self.selectButton.pressed.connect(self.loadDXF)
+        self.layout().addWidget(self.selectButton)
+
+        self.points = []
+
+    def loadDXF(self, path = None):
+        if path is None:
+            path = QFileDialog.getOpenFileName(None, 'Load core geometry', '', 'DXF Files (*.dxf)')[0]
+        if path != '': # If they cancel the dialog, path will be an empty string
+            dwg = ezdxf.readfile(path)
+            msp = dwg.modelspace()
+
+            self.points = []
+
+            for lwpl in msp.query('LWPOLYLINE'):
+                with lwpl.points() as points:
+                    self.points.append([(p[0] / 39.37, p[1] / 39.37) for p in points])
+
+            self.pointsChanged.emit()

--- a/uilib/propertyEditor.py
+++ b/uilib/propertyEditor.py
@@ -68,6 +68,7 @@ class propertyEditor(QWidget):
 
             self.editor.pointsChanged.connect(self.valueChanged.emit)
             self.editor.points = self.prop.getValue()
+            self.editor.preferences = self.preferences
 
             self.layout().addWidget(self.editor)
 

--- a/uilib/propertyEditor.py
+++ b/uilib/propertyEditor.py
@@ -1,4 +1,5 @@
 import motorlib
+from . import PolygonEditor
 
 import math
 
@@ -62,6 +63,14 @@ class propertyEditor(QWidget):
 
             self.layout().addWidget(self.editor)
 
+        elif type(prop) is motorlib.polygonProperty:
+            self.editor = PolygonEditor(self)
+
+            self.editor.pointsChanged.connect(self.valueChanged.emit)
+            self.editor.points = self.prop.getValue()
+
+            self.layout().addWidget(self.editor)
+
     def getValue(self):
         if type(self.prop) is motorlib.floatProperty:
             return motorlib.convert(self.editor.value(), self.dispUnit, self.prop.unit)
@@ -74,3 +83,6 @@ class propertyEditor(QWidget):
 
         elif type(self.prop) is motorlib.enumProperty:
             return self.editor.currentText()
+
+        elif type(self.prop) is motorlib.polygonProperty:
+            return self.editor.points


### PR DESCRIPTION
This PR adds a new grain type where the contour of the core is loaded from a DXF file. The DXF loader supports circles, lines, arcs, and polylines, and throws warnings whenever an unloadable entity is found. The user is able to specify the units of the DXF that is imported and is warned if open contours are found. This was tested with DXF files from SolidWorks, but it should work with files from other sources like Inkscape.

@tuxxi 