### PR TITLE
Change: Set EnableHighDpiScaling flag for high DPI support

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,10 +2,14 @@ import sys
 from app import App
 from PyQt5.QtCore import Qt
 
-# must be set before the app is constructed
-# cf. https://doc.qt.io/qt-5/highdpi.html
-# and https://www.riverbankcomputing.com/static/Docs/PyQt5/api/qtcore/qt.html#ApplicationAttribute
-App.setAttribute(Qt.AA_EnableHighDpiScaling)
+# Hide the hi-dpi switch behind a platform check
+# Works on Windows, unneccessary on macOS, and breaks GNOME
+# cf. https://github.com/reilleya/openMotor/pull/103#issuecomment-513507028
+if sys.platform == 'win32':
+    # must be set before the app is constructed
+    # cf. https://doc.qt.io/qt-5/highdpi.html
+    # and https://www.riverbankcomputing.com/static/Docs/PyQt5/api/qtcore/qt.html#ApplicationAttribute
+    App.setAttribute(Qt.AA_EnableHighDpiScaling)
 
 app = App(sys.argv)
 sys.exit(app.exec())

--- a/main.py
+++ b/main.py
@@ -1,5 +1,11 @@
 import sys
-import app
+from app import App
+from PyQt5.QtCore import Qt
 
-app = app.App(sys.argv)
+# must be set before the app is constructed
+# cf. https://doc.qt.io/qt-5/highdpi.html
+# and https://www.riverbankcomputing.com/static/Docs/PyQt5/api/qtcore/qt.html#ApplicationAttribute
+App.setAttribute(Qt.AA_EnableHighDpiScaling)
+
+app = App(sys.argv)
 sys.exit(app.exec())


### PR DESCRIPTION
This is handled at the OS layer by OSX and at the server layer by Wayland, whereas X11 and Windows place the responsibility of scaling on the app. Qt includes a flag to enable high-dpi support trivially, though it causes the app to be unwieldy because it's minimum size is still quite large.

I took a stab at a few other avenues, since it should "just work", but it seems to be pretty deep into the weeds with how Qt layouts work and I don't have enough experience with Qt to resolve them right now.

I don't have access to an OSX device, so I haven't been able to test this on other platforms.

Fixes #101