### PR TITLE
Ux improvements

### DIFF
--- a/uilib/widgets/grainSelector.py
+++ b/uilib/widgets/grainSelector.py
@@ -4,6 +4,7 @@ from PyQt5.QtCore import pyqtSignal
 class GrainSelector(QGroupBox):
 
     checksChanged = pyqtSignal()
+    doubleClicked = pyqtSignal()
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -49,3 +50,6 @@ class GrainSelector(QGroupBox):
             check.setCheckState(0)
         for check in checks:
             self.checks[check].setCheckState(2)
+            
+    def mouseDoubleClickEvent(self, event):
+        self.doubleClicked.emit()

--- a/uilib/widgets/mainWindow.py
+++ b/uilib/widgets/mainWindow.py
@@ -72,6 +72,9 @@ class Window(QMainWindow):
         for label in self.motorStatLabels:
             label.setText("-")
 
+    def doubleClickGrainSelector(self):
+        self.editGrain()
+
     def setupMotorEditor(self):
         self.ui.motorEditor.setPreferences(self.app.preferencesManager.preferences)
         self.ui.pushButtonEditGrain.pressed.connect(self.editGrain)
@@ -154,6 +157,8 @@ class Window(QMainWindow):
 
         self.ui.tableWidgetGrainList.itemSelectionChanged.connect(self.checkGrainSelection)
         self.checkGrainSelection()
+        
+        self.ui.tableWidgetGrainList.doubleClicked.connect(self.doubleClickGrainSelector)
 
     def setupGraph(self):
         self.ui.resultsWidget.resetPlot()

--- a/uilib/widgets/propellantMenu.py
+++ b/uilib/widgets/propellantMenu.py
@@ -62,6 +62,7 @@ class PropellantMenu(QDialog):
         self.setupPropList()
         self.setupButtons()
         self.manager.savePropellants()
+        self.ui.propEditor.loadProperties(newProp)
         self.repaint() # OSX needs this
 
     def deleteProp(self):


### PR DESCRIPTION
Users may now double click on grains or a nozzle item in the collection editor to edit the item.
Creating a new propellant in the propellant editor now automatically opens the created propellant.