### PR TITLE
UX Improvements

### DIFF
--- a/uilib/widgets/mainWindow.py
+++ b/uilib/widgets/mainWindow.py
@@ -72,6 +72,9 @@ class Window(QMainWindow):
         for label in self.motorStatLabels:
             label.setText("-")
 
+    def doubleClickGrainSelector(self):
+        self.editGrain()
+
     def setupMotorEditor(self):
         self.ui.motorEditor.setPreferences(self.app.preferencesManager.preferences)
         self.ui.pushButtonEditGrain.pressed.connect(self.editGrain)
@@ -154,6 +157,8 @@ class Window(QMainWindow):
 
         self.ui.tableWidgetGrainList.itemSelectionChanged.connect(self.checkGrainSelection)
         self.checkGrainSelection()
+        
+        self.ui.tableWidgetGrainList.doubleClicked.connect(self.doubleClickGrainSelector)
 
     def setupGraph(self):
         self.ui.resultsWidget.resetPlot()

--- a/uilib/widgets/propellantMenu.py
+++ b/uilib/widgets/propellantMenu.py
@@ -62,6 +62,7 @@ class PropellantMenu(QDialog):
         self.setupPropList()
         self.setupButtons()
         self.manager.savePropellants()
+        self.ui.propEditor.loadProperties(newProp)
         self.repaint() # OSX needs this
 
     def deleteProp(self):


### PR DESCRIPTION
Double clicking an item in the GrainList table widget will now open the editor interface. Creating a new propellant in the dialog will open its editor automatically.