### PR TITLE
Link to the latest release from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The calculations involved were sourced from Rocket Propulsion Elements by George
 
 Download
 -------
-The easiest way to use openMotor is to navigate to the 'releases' sidebar, click 'latest', and download the version for your system. From there, just unzip the file and run it. Alternatively, you can run it from source code to get the latest features. 
+You can download the latest version for your system [here](https://github.com/reilleya/openMotor/releases/latest). From there, just unzip the file and run it. Alternatively, you can run it from source code to get the latest features. 
 
 Building from Source
 --------------------


### PR DESCRIPTION
Hi, I am just a drive-by contributor from Joe Barnard's recent video (https://www.youtube.com/watch?v=eVvIZ3f2tSU). In his video he mentioned your software and I was intrigued and decided to check it out. Looks awesome! Great work.

I assume the software is aimed mainly at non-developers who might not be familiar with GitHub so upon reading through the readme, I got motivated to improve the Download section to link to the latest release directly. This way users not familiar with GitHub have an easier time just getting to the download without having to navigate the GitHub UI.

No hard feelings if you don't find this a worthwhile change! I know it is rather cosmetic, but I like to improve even the little things that I find for others' comfort.

Thank you for considering and take care!