### PR TITLE
Per-grain Core Mach number

### DIFF
--- a/motorlib/simResult.py
+++ b/motorlib/simResult.py
@@ -100,7 +100,7 @@ class LogChannel():
         return min(self.data)
 
 singleValueChannels = ['time', 'kn', 'pressure', 'force', 'volumeLoading', 'exitPressure', 'dThroat']
-multiValueChannels = ['mass', 'massFlow', 'massFlux', 'regression', 'web']
+multiValueChannels = ['mass', 'massFlow', 'massFlux', 'regression', 'web', 'machNumber']
 
 class SimulationResult():
     """A SimulationResult instance contains all results from a single simulation. It has a number of LogChannels, each
@@ -124,7 +124,8 @@ class SimulationResult():
             'regression': LogChannel('Regression Depth', tuple, 'm'),
             'web': LogChannel('Web', tuple, 'm'),
             'exitPressure': LogChannel('Nozzle Exit Pressure', float, 'Pa'),
-            'dThroat': LogChannel('Change in Throat Diameter', float, 'm')
+            'dThroat': LogChannel('Change in Throat Diameter', float, 'm'),
+            'machNumber': LogChannel('Core Mach Number', tuple, ''),
         }
 
     def addAlert(self, alert):
@@ -209,6 +210,19 @@ class SimulationResult():
         value = self.getPeakMassFlux()
         # Find the value to get the location
         for frame in self.channels['massFlux'].getData():
+            if value in frame:
+                return frame.index(value)
+        return None
+
+    def getPeakMachNumber(self):
+        """Returns the maximum core mach number observed at any grain end."""
+        return self.channels['machNumber'].getMax()
+
+    def getPeakMachNumberLocation(self):
+        """Returns the grain number at which the peak core mach number was observed."""
+        value = self.getPeakMachNumber()
+        # Find the value to get the location
+        for frame in self.channels['machNumber'].getData():
             if value in frame:
                 return frame.index(value)
         return None

--- a/uilib/defaults.py
+++ b/uilib/defaults.py
@@ -4,6 +4,7 @@ DEFAULT_PREFERENCES = {
     'general': {
         'maxPressure': 1500 * 6895,
         'maxMassFlux': 2 / 0.001422,
+        'maxMachNumber': 1,
         'minPortThroat': 2,
         'burnoutWebThres': 0.001 / 39.37,
         'burnoutThrustThres': 0.1,

--- a/uilib/fileIO.py
+++ b/uilib/fileIO.py
@@ -68,6 +68,10 @@ def getConfigPath():
 def passthrough(data):
     return data
     
+#0.6.0 to 0.6.1
+def migrateMotor_0_6_0_to_0_6_1(data):
+    data['config']['maxMachNumber'] = DEFAULT_PREFERENCES['general']['maxMachNumber']
+    return data
     
 #0.5.0 to 0.6.0
 def migrateMotor_0_5_0_to_0_6_0(data):
@@ -171,7 +175,7 @@ migrations = {
         'to': (0, 6, 1),
         fileTypes.PREFERENCES: passthrough,
         fileTypes.PROPELLANTS: passthrough,
-        fileTypes.MOTOR: passthrough,
+         fileTypes.MOTOR: migrateMotor_0_6_0_to_0_6_1,
         fileTypes.RECENT_FILES: passthrough
     },
     (0, 5, 0): {

--- a/uilib/widgets/resultsWidget.py
+++ b/uilib/widgets/resultsWidget.py
@@ -22,7 +22,7 @@ class ResultsWidget(QWidget):
         self.simResult = None
         self.cachedChecks = None
 
-        excludes = ['kn', 'pressure', 'force', 'mass', 'massFlow', 'massFlux', 'exitPressure', 'dThroat', 'volumeLoading']
+        excludes = ['kn', 'pressure', 'force', 'mass', 'massFlow', 'massFlux', 'exitPressure', 'dThroat', 'volumeLoading', 'machNumber']
         self.ui.channelSelectorX.setupChecks(False, default='time', exclude=excludes)
         self.ui.channelSelectorX.setTitle('X Axis')
         self.ui.channelSelectorY.setupChecks(True, default=['kn', 'pressure', 'force'], exclude=['time'])


### PR DESCRIPTION
Calculates the Mach number in each grain core using pressure, mass flux, and propellant properties using Newtons method. Per-grain core Mach is available for plotting, and also added a warning for the peak being above the configurable maxCoreMach number.