### PR TITLE
Fixed conical grains

### DIFF
--- a/motorlib/grains/conical.py
+++ b/motorlib/grains/conical.py
@@ -1,9 +1,6 @@
 """BATES submodule"""
 
-import numpy as np
-import skfmm
-from skimage import measure
-from math import atan, cos, sin
+from math import atan, cos, tan
 
 from ..grain import Grain
 from .. import geometry
@@ -17,7 +14,7 @@ class ConicalGrain(Grain):
         super().__init__()
         self.props['forwardCoreDiameter'] = FloatProperty('Forward Core Diameter', 'm', 0, 1)
         self.props['aftCoreDiameter'] = FloatProperty('Aft Core Diameter', 'm', 0, 1)
-        self.props['inhibitedEnds'] = EnumProperty('Inhibited ends', ['Both'])
+        self.props['inhibitedEnds'] = EnumProperty('Inhibited ends', ['Neither', 'Top', 'Bottom', 'Both'])
 
     def isCoreInverted(self):
         """A simple helper that returns 'true' if the core's foward diameter is larger than its aft diameter"""
@@ -25,24 +22,23 @@ class ConicalGrain(Grain):
 
     def getFrustumInfo(self, regDist):
         """Returns the dimensions of the grain's core at a given regression depth. The core is always a frustum and is
-        returned as the aft diameter, forward diameter, and length"""
+        returned as the forward diameter, aft diameter, and length"""
         grainDiameter = self.props['diameter'].getValue()
         aftDiameter = self.props['aftCoreDiameter'].getValue()
         forwardDiameter = self.props['forwardCoreDiameter'].getValue()
         grainLength = self.props['length'].getValue()
 
-        exposedFaces = 0
         inhibitedEnds = self.props['inhibitedEnds'].getValue()
-        if inhibitedEnds == 'Neither':
-            exposedFaces = 2
-        elif inhibitedEnds in ['Top', 'Bottom']:
-            exposedFaces = 1
+        forward_exposed = (inhibitedEnds in ('Neither', 'Bottom'))
+        aft_exposed     = (inhibitedEnds in ('Neither', 'Top'))
 
         # These calculations are easiest if we work in terms of the core's "large end" and "small end"
         if self.isCoreInverted():
             coreMajorDiameter, coreMinorDiameter = forwardDiameter, aftDiameter
+            major_exposed, minor_exposed = forward_exposed, aft_exposed
         else:
             coreMajorDiameter, coreMinorDiameter = aftDiameter, forwardDiameter
+            major_exposed, minor_exposed = aft_exposed, forward_exposed
 
         # Calculate the half angle of the core. This is done with without accounting for regression because it doesn't
         # change with regression
@@ -50,85 +46,85 @@ class ConicalGrain(Grain):
 
         # Expand both core diameters by the radial component of the core's regression vector. This is allowed to expand
         # beyond the casting tube as that condition is checked in a later step
-        regCoreMajorDiameter = coreMajorDiameter + (regDist * 2 * cos(angle))
-        regCoreMinorDiameter = coreMinorDiameter + (regDist * 2 * cos(angle))
-
+        regCoreMajorDiameter = coreMajorDiameter + (regDist * 2 * cos(angle)) - major_exposed * (regDist * 2 * tan(angle))
+        regCoreMinorDiameter = coreMinorDiameter + (regDist * 2 * cos(angle)) + minor_exposed * (regDist * 2 * tan(angle))
+ 
         # This is case where the larger core diameter has grown beyond the casting tube diameter. Once this happens,
         # the diameter of the large end of the core is clamped at the grain diameter and the length is changed to keep
         # the angle constant, which accounts for the regression of the grain at the major end.
         if regCoreMajorDiameter >= grainDiameter:
             majorFrustumDiameter = grainDiameter
-            minorFrustumDiameter = regCoreMinorDiameter
-            # How far past the grain diameter the major end has grown
-            effectiveReg = (regCoreMajorDiameter - grainDiameter) / 2
-            # Reduce the length of the frustum by the axial component of the regression vector
-            grainLength -= (effectiveReg / sin(angle))
-            # Account for the change in length due to face regression before the major end hit the casting tube
-            grainLength -= exposedFaces * (grainDiameter - coreMajorDiameter) / 2
-            # Don't double count face regression
-            grainLength += exposedFaces * effectiveReg
 
         # If the large end of the core hasn't reached the casting tube, we know that the small end hasn't either. In
         # this case we just return the current core diameters, and a length calculated from the inhibitor configuration
         else:
             majorFrustumDiameter = regCoreMajorDiameter
-            minorFrustumDiameter = regCoreMinorDiameter
-            grainLength -= exposedFaces * regDist
-            
-        if self.isCoreInverted():
-            return minorFrustumDiameter, majorFrustumDiameter, grainLength
 
-        return majorFrustumDiameter, minorFrustumDiameter, grainLength
+        # Minor frustum diameter is never clamped (the point when it would clamp is burnout), so we can use it to determine
+        # the length of the grain at any regression depth
+        minorFrustumDiameter = regCoreMinorDiameter
+        grainLength = (majorFrustumDiameter - minorFrustumDiameter) / (2 * tan(angle))
+        
+        if self.isCoreInverted():
+            return majorFrustumDiameter, minorFrustumDiameter, grainLength
+
+        return minorFrustumDiameter, majorFrustumDiameter, grainLength
 
     def getSurfaceAreaAtRegression(self, regDist):
         """Returns the surface area of the grain after it has regressed a linear distance of 'regDist'"""
-        aftDiameter, forwardDiameter, length = self.getFrustumInfo(regDist)
-        surfaceArea = geometry.frustumLateralSurfaceArea(aftDiameter, forwardDiameter, length)
+        forwardDiameter, aftDiameter, length = self.getFrustumInfo(regDist)
+        surfaceArea = geometry.frustumLateralSurfaceArea(forwardDiameter, aftDiameter, length)
 
         fullFaceArea = geometry.circleArea(self.props['diameter'].getValue())
-        if self.props['inhibitedEnds'].getValue() in ['Neither', 'Bottom']:
+        if self.props['inhibitedEnds'].getValue() in ('Neither', 'Bottom'):
             surfaceArea += fullFaceArea - geometry.circleArea(forwardDiameter)
-        if self.props['inhibitedEnds'].getValue() in ['Neither', 'Top']:
+        if self.props['inhibitedEnds'].getValue() in ('Neither', 'Top'):
             surfaceArea += fullFaceArea - geometry.circleArea(aftDiameter)
 
         return surfaceArea
 
     def getVolumeAtRegression(self, regDist):
         """Returns the volume of propellant in the grain after it has regressed a linear distance 'regDist'"""
-        aftDiameter, forwardDiameter, length = self.getFrustumInfo(regDist)
-        frustumVolume = geometry.frustumVolume(aftDiameter, forwardDiameter, length)
+        forwardDiameter, aftDiameter, length = self.getFrustumInfo(regDist)
+        frustumVolume = geometry.frustumVolume(forwardDiameter, aftDiameter, length)
         outerVolume = geometry.cylinderVolume(self.props['diameter'].getValue(), length)
 
         return outerVolume - frustumVolume
 
     def getWebLeft(self, regDist):
         """Returns the shortest distance the grain has to regress to burn out"""
-        aftDiameter, forwardDiameter, length = self.getFrustumInfo(regDist)
+        forwardDiameter, aftDiameter, length = self.getFrustumInfo(regDist)
+        wallLeft = (self.props['diameter'].getValue() - min(aftDiameter, forwardDiameter)) / 2
 
-        return (self.props['diameter'].getValue() - min(aftDiameter, forwardDiameter)) / 2
+        if self.props['inhibitedEnds'].getValue() == 'Both':
+            return wallLeft
+
+        return min(wallLeft, length)
 
     def getMassFlow(self, massIn, dTime, regDist, dRegDist, position, density):
         """Returns the mass flow at a point along the grain. Takes in the mass flow into the grain, a timestep, the
         distance the grain has regressed so far, the additional distance it will regress during the timestep, a
         position along the grain measured from the head end, and the density of the propellant."""
-
-        # For now these grains are only allowed with inhibited faces, so we can ignore a lot of messy logic
         unsteppedFrustum = self.getFrustumInfo(regDist)
         steppedFrustum = self.getFrustumInfo(regDist + dRegDist)
+        grainDiameter = self.props['diameter'].getValue()
+        aftUninhibited = (self.props['inhibitedEnds'].getValue() in ('Neither', 'Top'))
+        foreUninhibited = (self.props['inhibitedEnds'].getValue() in ('Neither', 'Bottom'))
 
-        """These have to be reordered, because getFrustumInfo returns (aft, forward, length), but splitFrustum wants
-        the position from the forward face"""
-        unsteppedFrustum = (unsteppedFrustum[1], unsteppedFrustum[0], unsteppedFrustum[2])
-        steppedFrustum = (steppedFrustum[1], steppedFrustum[0], steppedFrustum[2])
+        if position > dRegDist:
+            unsteppedPartialFrustum, _ = geometry.splitFrustum(*unsteppedFrustum, position - dRegDist * aftUninhibited)
+            steppedPartialFrustum, _ = geometry.splitFrustum(*steppedFrustum, steppedFrustum[2])
+        else:
+            unsteppedPartialFrustum, _ = geometry.splitFrustum(*unsteppedFrustum, position + dRegDist * foreUninhibited)
+            steppedPartialFrustum, _ = geometry.splitFrustum(*steppedFrustum, position)
+        
+        unsteppedFrustumVolume = geometry.frustumVolume(*unsteppedPartialFrustum)
+        steppedFrustumVolume = geometry.frustumVolume(*steppedPartialFrustum)
 
-         # Note that this assumes the forward end of the grain is still at postition 0 - inhibited
-        unsteppedPartialFrustum, _ = geometry.splitFrustum(*unsteppedFrustum, position)
-        steppedPartialFrustum, _ = geometry.splitFrustum(*steppedFrustum, position)
+        unsteppedPropVolume = geometry.cylinderVolume(grainDiameter, unsteppedPartialFrustum[2]) - unsteppedFrustumVolume
+        steppedPropVolume = geometry.cylinderVolume(grainDiameter, steppedPartialFrustum[2]) - steppedFrustumVolume
 
-        unsteppedVolume = geometry.frustumVolume(*unsteppedPartialFrustum)
-        steppedVolume = geometry.frustumVolume(*steppedPartialFrustum)
-
-        massFlow = (steppedVolume - unsteppedVolume) * density / dTime
+        massFlow = (unsteppedPropVolume - steppedPropVolume) * density / dTime
         massFlow += massIn
 
         return massFlow, steppedPartialFrustum[1]
@@ -137,17 +133,17 @@ class ConicalGrain(Grain):
         """Returns the mass flux at a point along the grain. Takes in the mass flow into the grain, a timestep, the
         distance the grain has regressed so far, the additional distance it will regress during the timestep, a
         position along the grain measured from the head end, and the density of the propellant."""
-
         massFlow, portDiameter = self.getMassFlow(massIn, dTime, regDist, dRegDist, position, density)
 
-        return massFlow / geometry.circleArea(portDiameter) # Index 1 is port diameter OR IS IT
+        return massFlow / geometry.circleArea(portDiameter)
 
     def getPeakMassFlux(self, massIn, dTime, regDist, dRegDist, density):
         """Uses the grain's mass flux method to return the max. Need to define this here because I'm not sure what
         it will look like"""
-
-        forwardMassFlux = self.getMassFlux(massIn, dTime, regDist, dRegDist, self.getEndPositions(regDist)[0], density)
-        aftMassFlux = self.getMassFlux(massIn, dTime, regDist, dRegDist, self.getEndPositions(regDist)[1], density)
+        _, _, length = self.getFrustumInfo(regDist)
+        
+        forwardMassFlux = self.getMassFlux(massIn, dTime, regDist, dRegDist, 0, density)
+        aftMassFlux = self.getMassFlux(massIn, dTime, regDist, dRegDist, length, density)
 
         return max(forwardMassFlux, aftMassFlux)
 
@@ -155,31 +151,34 @@ class ConicalGrain(Grain):
         """Returns the positions of the grain ends relative to the original (unburned) grain top. Returns a tuple like
         (forward, aft)"""
         originalLength = self.props['length'].getValue()
-        aftCoreDiameter, forwardCoreDiameter, currentLength = self.getFrustumInfo(regDist)
+        grainDiameter = self.props['diameter'].getValue()
+        forwardCoreDiameter, aftCoreDiameter, currentLength = self.getFrustumInfo(regDist)
+
         inhibitedEnds = self.props['inhibitedEnds'].getValue()
+        forward_exposed = (inhibitedEnds in ('Neither', 'Bottom'))
+        aft_exposed     = (inhibitedEnds in ('Neither', 'Top'))
 
+        # These calculations are easiest if we work in terms of the core's "large end" and "small end"
         if self.isCoreInverted():
-            if inhibitedEnds == 'Bottom' or inhibitedEnds == 'Both':
-                # Because all of the change in length is due to the forward end moving, the forward end's position is
-                # just the amount the the grain has regressed by, The aft end stays where it started
-                return (originalLength - currentLength, originalLength)
+            coreMajorDiameter, coreMinorDiameter = forwardCoreDiameter, aftCoreDiameter
+            major_exposed, minor_exposed = forward_exposed, aft_exposed
+        else:
+            coreMajorDiameter, coreMinorDiameter = aftCoreDiameter, forwardCoreDiameter
+            major_exposed, minor_exposed = aft_exposed, forward_exposed
 
-            # Neither or Top. In this case, the forward end moving accounts for almost all of the change in total grain
-            # length, except for the aft face having moved up by `regDist`, so that quantity is subtracted from the
-            # total change in grain length to get the forward end position
-            return (originalLength - currentLength - regDist, originalLength - regDist)
-
-        if inhibitedEnds == 'Top' or inhibitedEnds == 'Both':
-            # All of the change in grain length is due to the aft face moving, so the forward face stays at 0 and the
-            # aft face is at the regressed grain length
-            return (0, currentLength)
-
-        # Neither or Bottom
-        return (regDist, regDist + currentLength)
+        # Un-clamped major diameter        
+        if coreMajorDiameter < grainDiameter:
+            forward_regression, aft_regression = forward_exposed * regDist, aft_exposed * regDist
+            return forward_regression, originalLength - aft_regression
+        else:
+            minor_regression = minor_exposed * regDist
+            major_regression = (originalLength - currentLength) - minor_regression
+            forward_regression, aft_regression = (major_regression, minor_regression) if self.isCoreInverted() else (minor_regression, major_regression)
+            return forward_regression, originalLength - aft_regression
 
     def getPortArea(self, regDist):
         """Returns the area of the grain's port when it has regressed a distance of 'regDist'"""
-        aftCoreDiameter, _, _ = self.getFrustumInfo(regDist)
+        _, aftCoreDiameter, _ = self.getFrustumInfo(regDist)
 
         return geometry.circleArea(aftCoreDiameter)
 

--- a/test/unit/grains/conical.py
+++ b/test/unit/grains/conical.py
@@ -35,19 +35,19 @@ class ConicalGrainMethods(unittest.TestCase):
         testGrain.setProperties(properties)
 
         unregressed = testGrain.getFrustumInfo(0)
-        self.assertAlmostEqual(unregressed[0], properties['aftCoreDiameter'])
-        self.assertAlmostEqual(unregressed[1], properties['forwardCoreDiameter'])
+        self.assertAlmostEqual(unregressed[0], properties['forwardCoreDiameter'])
+        self.assertAlmostEqual(unregressed[1], properties['aftCoreDiameter'])
         self.assertAlmostEqual(unregressed[2], properties['length'])
 
         beforeHittingWall = testGrain.getFrustumInfo(0.001)
-        self.assertAlmostEqual(beforeHittingWall[0], 0.003999993750029297)
-        self.assertAlmostEqual(beforeHittingWall[1], 0.004499993750029296)
+        self.assertAlmostEqual(beforeHittingWall[0], 0.004499993750029296)
+        self.assertAlmostEqual(beforeHittingWall[1], 0.003999993750029297)
         self.assertAlmostEqual(beforeHittingWall[2], properties['length']) # Length hasn't changed yet
 
         hitWall = testGrain.getFrustumInfo(0.0038)
-        self.assertAlmostEqual(hitWall[0], 0.009599976250111327)
-        self.assertAlmostEqual(hitWall[1], properties['diameter']) # This end has burned all the way to the wall
-        self.assertAlmostEqual(hitWall[2], 0.08000468749267584)
+        self.assertAlmostEqual(hitWall[0], properties['diameter']) # This end has burned all the way to the wall
+        self.assertAlmostEqual(hitWall[1], 0.009599976250111327)
+        self.assertAlmostEqual(hitWall[2], 0.08000474997773462)
 
     def test_getSurfaceAreaAtRegression(self):
         properties = {
@@ -69,14 +69,14 @@ class ConicalGrainMethods(unittest.TestCase):
         self.assertAlmostEqual(testGrain.getSurfaceAreaAtRegression(0.001), 0.0013351790867045452)
 
         # For when uninibited conical grains work:
-        """testGrain.setProperty('inhibitedEnds', 'Top')
+        testGrain.setProperty('inhibitedEnds', 'Top')
         self.assertAlmostEqual(testGrain.getSurfaceAreaAtRegression(0), lateralArea + aftFaceArea)
 
         testGrain.setProperty('inhibitedEnds', 'Bottom')
         self.assertAlmostEqual(testGrain.getSurfaceAreaAtRegression(0), lateralArea + forwardFaceArea)
 
         testGrain.setProperty('inhibitedEnds', 'Neither')
-        self.assertAlmostEqual(testGrain.getSurfaceAreaAtRegression(0), lateralArea + forwardFaceArea + aftFaceArea)"""
+        self.assertAlmostEqual(testGrain.getSurfaceAreaAtRegression(0), lateralArea + forwardFaceArea + aftFaceArea)
 
     def test_getVolumeAtRegression(self):
         properties = {


### PR DESCRIPTION
Take II, should be working better now

Testing done:
- Verified frustum regression is correct via inspection
- Verified Kn regression in a standard conical configuration is correct via handcalc
- Verified full motor sim is exactly correct for a near-BATES configuration when compared to an identical BATES