### PR TITLE
FFM Surface Area calculation rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ __pycache__/
 # C extensions
 *.so
 
+# Cython
+*.c
+mathlib/_find_perimeter_cy.c
+
 # Distribution / packaging
 .Python
 build/
@@ -94,6 +98,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+myvenv
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -54,7 +54,19 @@ $ python setup.py build_ui
 ```
 Note that if you make changes to the UI using the `.ui` forms, you must re-build using the same command.
 
+#### Cython Files:
+to speed up some more computationally expensive parts of the codebase, openMotor uses the Cython programming language to run calculations in C.
+
+because the Cyphon code must be compiled separately for each system, you must build the library by running:
+```
+$ python setup.py build_ext --inplace
+```
+Note that if you make changes to any of the `.pyx` files, you must re-compile the Cython library using the same command.
+
+#### Run the Application:
+
 Once everything is set up, you can start openMotor by running: `python main.py`
+
 ###### Note: On some systems, Python 2 and 3 are installed simultaneously, so you may have to specify which version to run when creating the venv. After the venv has been activated, the programs `python` and `pip` are aliased to the python runtime specific for your venv, so use those (instead of `pip3` and `python3`, on e.g. Debian Linux)
 
 Data Files

--- a/mathlib/__init__.py
+++ b/mathlib/__init__.py
@@ -1,0 +1,1 @@
+from ._find_perimeter import find_perimeter

--- a/mathlib/_find_perimeter.py
+++ b/mathlib/_find_perimeter.py
@@ -1,0 +1,151 @@
+import numpy as np
+from ._find_perimeter_cy import _get_perimeter
+from collections import deque
+
+def find_perimeter(image, level,
+                  *,
+                  including_contours=False,
+                  fully_connected='low'):
+    """Find the perimeter of the iso-valued contours in a 2D array for a given level value.
+
+    Uses the "marching squares" method to compute the iso-valued contours of
+    the input 2D array for a particular level value. As segments are computed, 
+    their lengths are added to a total perimeter value which is eventually returned.
+
+    Parameters
+    ----------
+    image : 2D ndarray of double
+        Input image in which to find contours.
+    level : float
+        Value along which to find contours in the array.
+
+    Returns
+    -------
+    perimeter : float
+        The perimeter of the computed contours, using the distance between two adjacent 
+        image array points as the base unit.
+    contour : list of (n,2)-ndarrays
+        Each contour is an ndarray of shape ``(n, 2)``,
+        consisting of n ``(row, column)`` coordinates along the contour.
+        only returned if the
+
+    See Also
+    --------
+    skimage.measure.find_contours
+
+    Notes
+    -----
+    The marching squares algorithm is a special case of the marching cubes
+    algorithm [1]_.  A simple explanation is available here:
+
+    http://users.polytech.unice.fr/~lingrand/MarchingCubes/algo.html
+
+    .. warning::
+
+       Array coordinates/values are assumed to refer to the *center* of the
+       array element. Take a simple example input: ``[0, 1]``. The interpolated
+       position of 0.5 in this array is midway between the 0-element (at
+       ``x=0``) and the 1-element (at ``x=1``), and thus would fall at
+       ``x=0.5``.
+
+    This means that to find reasonable contours, it is best to find contours
+    midway between the expected "light" and "dark" values. In particular,
+    given a binarized array, *do not* choose to find contours at the low or
+    high value of the array. This will often yield degenerate contours,
+    especially around structures that are a single array element wide. Instead
+    choose a middle value, as above.
+
+    References
+    ----------
+    .. [1] Lorensen, William and Harvey E. Cline. Marching Cubes: A High
+           Resolution 3D Surface Construction Algorithm. Computer Graphics
+           (SIGGRAPH 87 Proceedings) 21(4) July 1987, p. 163-170).
+           :DOI:`10.1145/37401.37422`
+
+    Examples
+    --------
+    >>> a = np.zeros((3, 3))
+    >>> a[0, 0] = 1
+    >>> a
+    array([[1., 0., 0.],
+           [0., 0., 0.],
+           [0., 0., 0.]])
+    >>> find_perimeter(a, 0.5)
+    0.7071067811865476
+    """
+    if image.shape[0] < 2 or image.shape[1] < 2:
+        raise ValueError("Input array must be at least 2x2.")
+    if image.ndim != 2:
+        raise ValueError('Only 2D arrays are supported.')
+    (perimeter,segments) = _get_perimeter(image, float(level), fully_connected == 'high', including_contours)
+    contours = []
+    if including_contours:
+        contours = _assemble_contours(segments)
+    return perimeter, contours
+
+
+
+def _assemble_contours(segments):
+    current_index = 0
+    contours = {}
+    starts = {}
+    ends = {}
+    for from_point, to_point in segments:
+        # Ignore degenerate segments.
+        # This happens when (and only when) one vertex of the square is
+        # exactly the contour level, and the rest are above or below.
+        # This degenerate vertex will be picked up later by neighboring
+        # squares.
+        if from_point == to_point:
+            continue
+
+        tail, tail_num = starts.pop(to_point, (None, None))
+        head, head_num = ends.pop(from_point, (None, None))
+
+        if tail is not None and head is not None:
+            # We need to connect these two contours.
+            if tail is head:
+                # We need to closed a contour: add the end point
+                head.append(to_point)
+            else:  # tail is not head
+                # We need to join two distinct contours.
+                # We want to keep the first contour segment created, so that
+                # the final contours are ordered left->right, top->bottom.
+                if tail_num > head_num:
+                    # tail was created second. Append tail to head.
+                    head.extend(tail)
+                    # Remove tail from the detected contours
+                    contours.pop(tail_num, None)
+                    # Update starts and ends
+                    starts[head[0]] = (head, head_num)
+                    ends[head[-1]] = (head, head_num)
+                else:  # tail_num <= head_num
+                    # head was created second. Prepend head to tail.
+                    tail.extendleft(reversed(head))
+                    # Remove head from the detected contours
+                    starts.pop(head[0], None)  # head[0] can be == to_point!
+                    contours.pop(head_num, None)
+                    # Update starts and ends
+                    starts[tail[0]] = (tail, tail_num)
+                    ends[tail[-1]] = (tail, tail_num)
+        elif tail is None and head is None:
+            # We need to add a new contour
+            new_contour = deque((from_point, to_point))
+            contours[current_index] = new_contour
+            starts[from_point] = (new_contour, current_index)
+            ends[to_point] = (new_contour, current_index)
+            current_index += 1
+        elif head is None:  # tail is not None
+            # tail first element is to_point: the new segment should be
+            # prepended.
+            tail.appendleft(from_point)
+            # Update starts
+            starts[from_point] = (tail, tail_num)
+        else:  # tail is None and head is not None:
+            # head last element is from_point: the new segment should be
+            # appended
+            head.append(to_point)
+            # Update ends
+            ends[to_point] = (head, head_num)
+
+    return [np.array(contour) for _, contour in sorted(contours.items())]

--- a/mathlib/_find_perimeter_cy.pyx
+++ b/mathlib/_find_perimeter_cy.pyx
@@ -1,0 +1,199 @@
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: nonecheck=False
+# cython: wraparound=False
+cimport numpy as cnp
+from libc.math cimport sqrt
+
+# helper function to calculate length of diagonals without python
+cdef inline cnp.float64_t hypot(cnp.float64_t x, cnp.float64_t y) nogil:
+    return sqrt((x * x) + (y * y))
+
+# lerp helper function
+cdef inline cnp.float64_t _get_fraction(cnp.float64_t from_value,
+                                        cnp.float64_t to_value,
+                                        cnp.float64_t level) nogil:
+    if (to_value == from_value):
+        return 0
+    return ((level - from_value) / (to_value - from_value))
+
+
+def _get_perimeter(cnp.float64_t[:, :] array, cnp.float64_t level,
+                   bint vertex_connect_high, bint returning_contours):
+
+    """Iterate across the given array in a marching-squares fashion,
+    looking for segments that cross 'level'. If such a segment is
+    found, its length is added to the total perimeter,
+    which is returned by the function.  if vertex_connect_high is
+    nonzero, high-values pixels are considered to be face+vertex
+    connected into objects; otherwise low-valued pixels are.
+    """
+
+    # The plan is to iterate a 2x2 square across the input array. This means
+    # that the upper-left corner of the square needs to iterate across a
+    # sub-array that's one-less-large in each direction (so that the square
+    # never steps out of bounds). The square is represented by four pointers:
+    # ul, ur, ll, and lr (for 'upper left', etc.). We also maintain the current
+    # 2D coordinates for the position of the upper-left pointer. Note that we
+    # ensured that the array is of type 'float64' and is C-contiguous (last
+    # index varies the fastest).
+    #
+    # There are sixteen different possible square types, diagramed below.
+    # A + indicates that the vertex is above the contour value, and a -
+    # indicates that the vertex is below or equal to the contour value.
+    # The vertices of each square are:
+    # ul ur
+    # ll lr
+    # and can be treated as a binary value with the bits in that order. Thus
+    # each square case can be numbered:
+    #  0--   1+-   2-+   3++   4--   5+-   6-+   7++
+    #   --    --    --    --    +-    +-    +-    +-
+    #
+    #  8--   9+-  10-+  11++  12--  13+-  14-+  15++
+    #   -+    -+    -+    -+    ++    ++    ++    ++
+    #
+    # The position of the line segment that cuts through (or
+    # doesn't, in case 0 and 15) each square is clear, except in
+    # cases 6 and 9. In this case, the segments are assumed to connect the
+    # negative sections. Lines like \\ are drawn through square 6, and
+    # lines like // are drawn through square 9.
+
+    cdef bint c_returning_contours = returning_contours  # converting to c variable
+    cdef list segments = []
+    cdef cnp.float64_t perimeter
+    cdef cnp.float64_t addVar  # accumulator variable (required by compiler)
+
+    cdef unsigned char square_case
+    cdef tuple top_tuple, bottom_tuple, left_tuple, right_tuple
+    cdef cnp.float64_t top, bottom, left, right
+    cdef cnp.float64_t ul, ur, ll, lr
+    cdef Py_ssize_t r0, r1, c0, c1
+
+    perimeter = 0
+
+    # not simulating 3 closest pixels to the edge
+    for r0 in range(3, array.shape[0] - 4):
+        for c0 in range(3, array.shape[1] - 4):
+
+            r1, c1 = r0 + 1, c0 + 1
+
+            ul = array[r0, c0]
+            ur = array[r0, c1]
+            ll = array[r1, c0]
+            lr = array[r1, c1]
+
+            square_case = (
+                (ul > level)
+                + ((ur > level) *2)
+                + ((ll > level) * 4)
+                + ((lr > level) * 8))
+
+            if square_case in [0, 15]:
+                # only do anything if there's a line passing through the
+                # square. Cases 0 and 15 are entirely below/above the contour.
+                continue
+
+            if ((array.shape[0]/2) - 3
+                    < hypot(
+                        r0 + 0.5 - (array.shape[0]/2),
+                        c0 + 0.5 - (array.shape[1]/2)
+                    ) and not c_returning_contours):
+
+                # skips this square if outside the motor radius
+                # tolerance of 3 adapted from geometry.length function
+                continue
+
+            top = _get_fraction(ul, ur, level)
+            bottom = _get_fraction(ll, lr, level)
+            left = _get_fraction(ll, ul, level)
+            right = _get_fraction(lr, ur, level)
+
+            # calculating coordinates incase they are needed for contours
+            if c_returning_contours:
+                top_tuple = r0, c0 + _get_fraction(ul, ur, level)
+                bottom_tuple = r1, c0 + _get_fraction(ll, lr, level)
+                left_tuple = r0 + _get_fraction(ul, ll, level), c0
+                right_tuple = r0 + _get_fraction(ur, lr, level), c1
+
+            addVar = 0
+
+            if (square_case == 1):
+                # top to left
+                if c_returning_contours:
+                    segments.append((top_tuple, left_tuple))
+                addVar = hypot(top, 1-left)
+            elif (square_case == 2):
+                # right to top
+                if c_returning_contours:
+                    segments.append((right_tuple, top_tuple))
+                addVar = hypot(1-top, 1-right)
+            elif (square_case == 3):
+                # right to left
+                if c_returning_contours:
+                    segments.append((right_tuple, left_tuple))
+                addVar = hypot(right-left, 1)
+            elif (square_case == 4):
+                # left to bottom
+                if c_returning_contours:
+                    segments.append((left_tuple, bottom_tuple))
+                addVar = hypot(left, bottom)
+            elif (square_case == 5):
+                # top to bottom
+                if c_returning_contours:
+                    segments.append((top_tuple, bottom_tuple))
+                addVar = hypot(top-bottom, 1)
+            elif (square_case == 6):
+                if c_returning_contours:
+                    if vertex_connect_high:
+                        segments.append((left_tuple, top_tuple))
+                        segments.append((right_tuple, bottom_tuple))
+                    else:
+                        segments.append((right_tuple, top_tuple))
+                        segments.append((left_tuple, bottom_tuple))
+                addVar = hypot(1-top, 1-right) + hypot(left, bottom)
+            elif (square_case == 7):
+                # right to bottom
+                if c_returning_contours:
+                    segments.append((right_tuple, bottom_tuple))
+                addVar = hypot(1-bottom, right)
+            elif (square_case == 8):
+                # bottom to right
+                if c_returning_contours:
+                    segments.append((bottom_tuple, right_tuple))
+                addVar = hypot(1-bottom, right)
+            elif (square_case == 9):
+                if c_returning_contours:
+                    if vertex_connect_high:
+                        segments.append((top_tuple, right_tuple))
+                        segments.append((bottom_tuple, left_tuple))
+                    else:
+                        segments.append((top_tuple, left_tuple))
+                        segments.append((bottom_tuple, right_tuple))
+                addVar = hypot(top, 1-left) + hypot(1-bottom, right)
+            elif (square_case == 10):
+                # bottom to top
+                if c_returning_contours:
+                    segments.append((bottom_tuple, top_tuple))
+                addVar = hypot(top-bottom, 1)
+            elif (square_case == 11):
+                # bottom to left
+                if c_returning_contours:
+                    segments.append((bottom_tuple, left_tuple))
+                addVar = hypot(left, bottom)
+            elif (square_case == 12):
+                # lef to right
+                if c_returning_contours:
+                    segments.append((left_tuple, right_tuple))
+                addVar = hypot(right-left, 1)
+            elif (square_case == 13):
+                # top to right
+                if c_returning_contours:
+                    segments.append((top_tuple, right_tuple))
+                addVar = hypot(1-top, 1-right)
+            elif (square_case == 14):
+                # left to top
+                if c_returning_contours:
+                    segments.append((left_tuple, top_tuple))
+                addVar = hypot(top, 1-left)
+            perimeter += addVar
+    return perimeter, segments

--- a/motorlib/grain.py
+++ b/motorlib/grain.py
@@ -5,6 +5,7 @@ from abc import abstractmethod
 
 import numpy as np
 import skfmm
+import mathlib
 from skimage import measure
 from scipy.signal import savgol_filter
 from scipy import interpolate
@@ -282,14 +283,8 @@ class FmmGrain(PerforatedGrain):
 
     def getCorePerimeter(self, regDist):
         mapDist = self.normalize(regDist)
-
-        corePerimeter = 0
-        contours = measure.find_contours(self.regressionMap, mapDist, fully_connected='low')
-        for contour in contours:
-            corePerimeter += self.mapToLength(geometry.length(contour, self.mapDim))
-
-        return corePerimeter
-
+        return self.mapToLength(mathlib.find_perimeter(self.regressionMap, mapDist)[0])
+    
     def getFaceArea(self, regDist):
         mapDist = self.normalize(regDist)
         index = int(mapDist * self.mapDim)
@@ -325,7 +320,9 @@ class FmmGrain(PerforatedGrain):
             for dist in np.linspace(0, regmax, numContours):
                 contours.append([])
                 contourLengths[dist] = 0
-                layerContours = measure.find_contours(self.regressionMap, dist, fully_connected='low')
+                layerContours = mathlib.find_perimeter(self.regressionMap, dist,
+                                                       fully_connected='low',
+                                                       including_contours=True)[1]
                 for contour in layerContours:
                     contours[-1].append(geometry.clean(contour, self.mapDim, 3))
                     contourLengths[dist] += geometry.length(contour, self.mapDim)

--- a/motorlib/grains/bates.py
+++ b/motorlib/grains/bates.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import skfmm
-from skimage import measure
+import mathlib
 
 from ..grain import PerforatedGrain
 from .. import geometry
@@ -74,7 +74,7 @@ class BatesGrain(PerforatedGrain):
             for dist in np.linspace(0, regmax, numContours):
                 contours.append([])
                 contourLengths[dist] = 0
-                layerContours = measure.find_contours(regressionMap, dist, fully_connected='high')
+                layerContours = mathlib.find_perimeter(regressionMap, dist, fully_connected='high', including_contours=True)[1]
                 for contour in layerContours:
                     contours[-1].append(contour)
                     contourLengths[dist] += geometry.length(contour, mapDim)

--- a/motorlib/grains/rodTube.py
+++ b/motorlib/grains/rodTube.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import skfmm
-from skimage import measure
+import mathlib
 
 from ..grain import PerforatedGrain
 from .. import geometry
@@ -107,7 +107,7 @@ class RodTubeGrain(PerforatedGrain):
             for dist in np.linspace(0, regmax, numContours):
                 contours.append([])
                 contourLengths[dist] = 0
-                layerContours = measure.find_contours(regressionMap, dist, fully_connected='high')
+                layerContours = mathlib.find_perimeter(regressionMap, dist, fully_connected='high', including_contours=True)[1]
                 for contour in layerContours:
                     contours[-1].append(contour)
                     contourLengths[dist] += geometry.length(contour, mapDim)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cycler==0.11.0
+cython == 3.0.11
 decorator==5.1.1
 docopt==0.6.2
 ezdxf==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Extension
 from uilib.fileIO import appVersionStr
+from Cython.Build import cythonize
+import numpy
+import multiprocessing
 
 try:
     from pyqt_distutils.build_ui import build_ui
@@ -9,10 +12,23 @@ except ImportError:
     build_ui = None  # user won't have pyqt_distutils when deploying
     cmdclass = {}
 
+extensions = [
+    Extension(
+        "mathlib._find_perimeter_cy",  # Full module path
+        ["mathlib/_find_perimeter_cy.pyx"],  # File location
+        define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')],
+        include_dirs=[numpy.get_include()]
+    )
+]
+
 setup(
     name='openMotor',
     version=appVersionStr,
     license='GPLv3',
+    ext_modules=cythonize(extensions, 
+            nthreads = multiprocessing.cpu_count(), 
+            compiler_directives={'language_level': 3}
+            ),
     packages=find_packages(),
     url='https://github.com/reilleya/openMotor',
     description='An open-source internal ballistics simulator for rocket motor experimenters',


### PR DESCRIPTION
Hey there! 
My university team has been working with Finocyl grains and recently found a way to speed up FFM Sims.

A large part of the FFM grain simulation run time is spent getting contours from the SciKit image library. 
The current implementation uses an [open source Cython function](https://scikit-image.org/docs/0.23.x/auto_examples/edges/plot_contours.html) to retrieve an array of line segments.
The array is never actually used for anything, open motors code just retrieves the sum length of all lines within the motor.

To work around this, we developed a Cython function titled “get_perimeter()"
The function sums the length of all the lines as it finds them, and never stores them into an array.
We ran some tests using profilers, and a fully Finocyl motor ran 6x faster during simulation.

There is a slight change in how lines on the edge of the motor are trimmed, resulting in a ~0.1% difference in pressure in our test simulations.

Please let me know if any changes need to be made!
