### PR TITLE
Fix core mach calculation

### DIFF
--- a/uilib/defaults.py
+++ b/uilib/defaults.py
@@ -4,7 +4,7 @@ DEFAULT_PREFERENCES = {
     'general': {
         'maxPressure': 1500 * 6895,
         'maxMassFlux': 2 / 0.001422,
-        'maxMachNumber': 1,
+        'maxMachNumber': 0.7,
         'minPortThroat': 2,
         'burnoutWebThres': 0.001 / 39.37,
         'burnoutThrustThres': 0.1,


### PR DESCRIPTION
Fixed core mach number calculation. R was erroneously assumed to be gas constant when it should be gas constant / molecular weight