### PR TITLE
Spurious high core mach fix

### DIFF
--- a/motorlib/constants.py
+++ b/motorlib/constants.py
@@ -5,3 +5,6 @@ gasConstant = 8314.462618
 
 # Standard gravitation acceleration (g), in units of m/s**2
 standardGravity = 9.80665
+
+# Atmospheric pressure (1 atm), in units of Pa
+atmosphericPressure = 101325

--- a/motorlib/motor.py
+++ b/motorlib/motor.py
@@ -6,7 +6,7 @@ from . import geometry
 from .simResult import SimulationResult, SimAlert, SimAlertLevel, SimAlertType
 from .grains import EndBurningGrain
 from .properties import PropertyCollection, FloatProperty, IntProperty
-from .constants import gasConstant
+from .constants import gasConstant, atmosphericPressure
 from scipy.optimize import newton
 import numpy as np
 
@@ -115,7 +115,7 @@ class Motor():
         """Calculates the mach number in the core of a grain for a given chamber pressure and mass flux."""
         _, _, gamma, T, molarMass = self.propellant.getCombustionProperties(chamberPres)
 
-        if chamberPres <= 1e-6:
+        if chamberPres <= atmosphericPressure: # Mach calculation gets weird at low chamber pressures
             return 0
 
         def machFunc(M, chamberPres, massFlux, gamma, T, molarMass, gasConstant):


### PR DESCRIPTION
Fix for spurious high core Machs caused by chamber pressure dropping at the beginning or end of a burn. Just made it cutoff when chamber pressure is below 1 atm which seems to have fixed the problem.
Example attached:
<img width="899" height="590" alt="image" src="https://github.com/user-attachments/assets/8ec72bb4-459a-4084-94a7-6e3908508c63" />
