### PR TITLE
Parameterized and increased physical maximums

### DIFF
--- a/motorlib/constants.py
+++ b/motorlib/constants.py
@@ -8,3 +8,9 @@ standardGravity = 9.80665
 
 # Atmospheric pressure (1 atm), in units of Pa
 atmosphericPressure = 101325
+
+# Maximum reference length for capping user inputs, in units of meters
+maximumRefLength = 24.6
+
+# Maximum reference diameter for capping user inputs, in units of meters
+maximumRefDiameter = 6.6

--- a/motorlib/grain.py
+++ b/motorlib/grain.py
@@ -12,6 +12,7 @@ from scipy import interpolate
 from . import geometry
 from .simResult import SimAlert, SimAlertLevel, SimAlertType
 from .properties import FloatProperty, EnumProperty, PropertyCollection
+from .constants import maximumRefDiameter, maximumRefLength
 
 class Grain(PropertyCollection):
     """A basic propellant grain. This is the class that all grains inherit from. It provides a few properties and
@@ -19,8 +20,8 @@ class Grain(PropertyCollection):
     geomName = None
     def __init__(self):
         super().__init__()
-        self.props['diameter'] = FloatProperty('Diameter', 'm', 0, 1)
-        self.props['length'] = FloatProperty('Length', 'm', 0, 3)
+        self.props['diameter'] = FloatProperty('Diameter', 'm', 0, maximumRefDiameter)
+        self.props['length'] = FloatProperty('Length', 'm', 0, maximumRefLength)
 
     def getVolumeSlice(self, regDist, dRegDist):
         """Returns the amount of propellant volume consumed as the grain regresses from a distance of 'regDist' to

--- a/motorlib/grains/bates.py
+++ b/motorlib/grains/bates.py
@@ -15,7 +15,7 @@ class BatesGrain(PerforatedGrain):
     geomName = "BATES"
     def __init__(self):
         super().__init__()
-        self.props['coreDiameter'] = FloatProperty('Core Diameter', 'm', 0, 1)
+        self.props['coreDiameter'] = FloatProperty('Core Diameter', 'm', 0, 5)
 
     def simulationSetup(self, config):
         self.wallWeb = (self.props['diameter'].getValue() - self.props['coreDiameter'].getValue()) / 2

--- a/motorlib/grains/cGrain.py
+++ b/motorlib/grains/cGrain.py
@@ -5,6 +5,7 @@ import numpy as np
 from ..grain import FmmGrain
 from ..properties import FloatProperty
 from ..simResult import SimAlert, SimAlertLevel, SimAlertType
+from ..constants import maximumRefDiameter
 
 class CGrain(FmmGrain):
     """Defines a C grain, which is a cylindrical grain with a single slot taken out. The slot is a rectangular section
@@ -13,8 +14,8 @@ class CGrain(FmmGrain):
     geomName = 'C Grain'
     def __init__(self):
         super().__init__()
-        self.props['slotWidth'] = FloatProperty('Slot width', 'm', 0, 1)
-        self.props['slotOffset'] = FloatProperty('Slot offset', 'm', -1, 1)
+        self.props['slotWidth'] = FloatProperty('Slot width', 'm', 0, maximumRefDiameter)
+        self.props['slotOffset'] = FloatProperty('Slot offset', 'm', -maximumRefDiameter, maximumRefDiameter)
 
         self.props['slotOffset'].setValue(0)
 

--- a/motorlib/grains/conical.py
+++ b/motorlib/grains/conical.py
@@ -6,14 +6,15 @@ from ..grain import Grain
 from .. import geometry
 from ..simResult import SimAlert, SimAlertLevel, SimAlertType
 from ..properties import FloatProperty, EnumProperty
+from ..constants import maximumRefDiameter
 
 class ConicalGrain(Grain):
     """A conical grain is similar to a BATES grain except it has different core diameters at each end."""
     geomName = "Conical"
     def __init__(self):
         super().__init__()
-        self.props['forwardCoreDiameter'] = FloatProperty('Forward Core Diameter', 'm', 0, 1)
-        self.props['aftCoreDiameter'] = FloatProperty('Aft Core Diameter', 'm', 0, 1)
+        self.props['forwardCoreDiameter'] = FloatProperty('Forward Core Diameter', 'm', 0, maximumRefDiameter)
+        self.props['aftCoreDiameter'] = FloatProperty('Aft Core Diameter', 'm', 0, maximumRefDiameter)
         self.props['inhibitedEnds'] = EnumProperty('Inhibited ends', ['Neither', 'Top', 'Bottom', 'Both'])
 
     def isCoreInverted(self):

--- a/motorlib/grains/dGrain.py
+++ b/motorlib/grains/dGrain.py
@@ -3,6 +3,7 @@
 from ..grain import FmmGrain
 from ..properties import FloatProperty
 from ..simResult import SimAlert, SimAlertLevel, SimAlertType
+from ..constants import maximumRefDiameter
 
 class DGrain(FmmGrain):
     """Defines a D grain, which is a grain that has no propellant past a chord that is a user-specified distance from
@@ -10,7 +11,7 @@ class DGrain(FmmGrain):
     geomName = 'D Grain'
     def __init__(self):
         super().__init__()
-        self.props['slotOffset'] = FloatProperty('Slot offset', 'm', -1, 1)
+        self.props['slotOffset'] = FloatProperty('Slot offset', 'm', -maximumRefDiameter, maximumRefDiameter)
 
         self.props['slotOffset'].setValue(0)
 

--- a/motorlib/grains/finocyl.py
+++ b/motorlib/grains/finocyl.py
@@ -5,6 +5,7 @@ import numpy as np
 from ..grain import FmmGrain
 from ..properties import FloatProperty, IntProperty, BooleanProperty
 from ..simResult import SimAlert, SimAlertLevel, SimAlertType
+from ..constants import maximumRefDiameter
 
 class Finocyl(FmmGrain):
     """A finocyl (fins on cylinder) grain has a circular core with a number of rectangular extensions that start at the
@@ -13,9 +14,9 @@ class Finocyl(FmmGrain):
     def __init__(self):
         super().__init__()
         self.props['numFins'] = IntProperty('Number of fins', '', 0, 64)
-        self.props['finWidth'] = FloatProperty('Fin width', 'm', 0, 1)
-        self.props['finLength'] = FloatProperty('Fin length', 'm', 0, 1)
-        self.props['coreDiameter'] = FloatProperty('Core diameter', 'm', 0, 1)
+        self.props['finWidth'] = FloatProperty('Fin width', 'm', 0, maximumRefDiameter)
+        self.props['finLength'] = FloatProperty('Fin length', 'm', 0, maximumRefDiameter)
+        self.props['coreDiameter'] = FloatProperty('Core diameter', 'm', 0, maximumRefDiameter)
         self.props['invertedFins'] = BooleanProperty('Inverted fins')
 
     def generateCoreMap(self):

--- a/motorlib/grains/moonBurner.py
+++ b/motorlib/grains/moonBurner.py
@@ -3,14 +3,15 @@
 from ..grain import FmmGrain
 from ..properties import FloatProperty
 from ..simResult import SimAlert, SimAlertLevel, SimAlertType
+from ..constants import maximumRefDiameter
 
 class MoonBurner(FmmGrain):
     """A moonburner is very similar to a BATES grain except the core is off center by a specified distance."""
     geomName = 'Moon Burner'
     def __init__(self):
         super().__init__()
-        self.props['coreOffset'] = FloatProperty('Core offset', 'm', 0, 1)
-        self.props['coreDiameter'] = FloatProperty('Core diameter', 'm', 0, 1)
+        self.props['coreOffset'] = FloatProperty('Core offset', 'm', 0, maximumRefDiameter)
+        self.props['coreDiameter'] = FloatProperty('Core diameter', 'm', 0, maximumRefDiameter)
 
     def generateCoreMap(self):
         coreRadius = self.normalize(self.props['coreDiameter'].getValue()) / 2

--- a/motorlib/grains/rodTube.py
+++ b/motorlib/grains/rodTube.py
@@ -8,6 +8,7 @@ from ..grain import PerforatedGrain
 from .. import geometry
 from ..simResult import SimAlert, SimAlertLevel, SimAlertType
 from ..properties import FloatProperty
+from ..constants import maximumRefDiameter
 
 class RodTubeGrain(PerforatedGrain):
     """Tbe rod and tube grain resembles a BATES grain except that it features a fully-uninhibited rod of propellant in
@@ -15,9 +16,9 @@ class RodTubeGrain(PerforatedGrain):
     geomName = "Rod and Tube"
     def __init__(self):
         super().__init__()
-        self.props['coreDiameter'] = FloatProperty('Core Diameter', 'm', 0, 1)
-        self.props['rodDiameter'] = FloatProperty('Rod Diameter', 'm', 0, 1)
-        self.props['supportDiameter'] = FloatProperty('Support Diameter', 'm', 0, 1)
+        self.props['coreDiameter'] = FloatProperty('Core Diameter', 'm', 0, maximumRefDiameter)
+        self.props['rodDiameter'] = FloatProperty('Rod Diameter', 'm', 0, maximumRefDiameter)
+        self.props['supportDiameter'] = FloatProperty('Support Diameter', 'm', 0, maximumRefDiameter)
         self.tubeWeb = None
         self.rodWeb = None
 

--- a/motorlib/grains/star.py
+++ b/motorlib/grains/star.py
@@ -5,6 +5,7 @@ import numpy as np
 from ..grain import FmmGrain
 from ..properties import IntProperty, FloatProperty
 from ..simResult import SimAlert, SimAlertLevel, SimAlertType
+from ..constants import maximumRefDiameter
 
 class StarGrain(FmmGrain):
     """A star grain has a core shaped like a star."""
@@ -12,8 +13,8 @@ class StarGrain(FmmGrain):
     def __init__(self):
         super().__init__()
         self.props['numPoints'] = IntProperty('Number of points', '', 0, 64)
-        self.props['pointLength'] = FloatProperty('Point length', 'm', 0, 1)
-        self.props['pointWidth'] = FloatProperty('Point base width', 'm', 0, 1)
+        self.props['pointLength'] = FloatProperty('Point length', 'm', 0, maximumRefDiameter)
+        self.props['pointWidth'] = FloatProperty('Point base width', 'm', 0, maximumRefDiameter)
 
     def generateCoreMap(self):
         numPoints = self.props['numPoints'].getValue()

--- a/motorlib/grains/xCore.py
+++ b/motorlib/grains/xCore.py
@@ -5,14 +5,15 @@ import numpy as np
 from ..grain import FmmGrain
 from ..properties import FloatProperty
 from ..simResult import SimAlert, SimAlertLevel, SimAlertType
+from ..constants import maximumRefDiameter
 
 class XCore(FmmGrain):
     """An X Core grain has a core shaped like a plus sign or an X."""
     geomName = 'X Core'
     def __init__(self):
         super().__init__()
-        self.props['slotWidth'] = FloatProperty('Slot width', 'm', 0, 1)
-        self.props['slotLength'] = FloatProperty('Slot length', 'm', 0, 1)
+        self.props['slotWidth'] = FloatProperty('Slot width', 'm', 0, maximumRefDiameter)
+        self.props['slotLength'] = FloatProperty('Slot length', 'm', 0, maximumRefDiameter)
 
     def generateCoreMap(self):
         slotWidth = self.normalize(self.props['slotWidth'].getValue())

--- a/motorlib/nozzle.py
+++ b/motorlib/nozzle.py
@@ -6,7 +6,7 @@ from scipy.optimize import fsolve
 from .properties import FloatProperty, PropertyCollection
 from . import geometry
 from .simResult import SimAlert, SimAlertLevel, SimAlertType
-
+from .constants import maximumRefDiameter, maximumRefLength
 
 def eRatioFromPRatio(k, pRatio):
     """Returns the expansion ratio of a nozzle given the pressure ratio it causes."""
@@ -16,12 +16,12 @@ class Nozzle(PropertyCollection):
     """An object that contains the details about a motor's nozzle."""
     def __init__(self):
         super().__init__()
-        self.props['throat'] = FloatProperty('Throat Diameter', 'm', 0, 0.5)
-        self.props['exit'] = FloatProperty('Exit Diameter', 'm', 0, 1)
+        self.props['throat'] = FloatProperty('Throat Diameter', 'm', 0, maximumRefDiameter)
+        self.props['exit'] = FloatProperty('Exit Diameter', 'm', 0, maximumRefDiameter)
         self.props['efficiency'] = FloatProperty('Efficiency', '', 0, 2)
         self.props['divAngle'] = FloatProperty('Divergence Half Angle', 'deg', 0, 90)
         self.props['convAngle'] = FloatProperty('Convergence Half Angle', 'deg', 0, 90)
-        self.props['throatLength'] = FloatProperty('Throat Length', 'm', 0, 0.5)
+        self.props['throatLength'] = FloatProperty('Throat Length', 'm', 0, maximumRefLength / 10)
         self.props['slagCoeff'] = FloatProperty('Slag Buildup Coefficient', '(m*Pa)/s', 0, 1e6)
         self.props['erosionCoeff'] = FloatProperty('Throat Erosion Coefficient', 'm/(s*Pa)', 0, 1e6)
 

--- a/motorlib/simResult.py
+++ b/motorlib/simResult.py
@@ -186,7 +186,7 @@ class SimulationResult():
         imp = self.getImpulse()
         if imp < 1.25: # This is to avoid a domain error finding log(0)
             return 'N/A'
-        return chr(int(math.log(imp / 1.25, 2)) + 65) + str(int(self.getAverageForce()))
+        return ('A' if imp > (1.25 * (2**26)) else '') + chr(int(math.log(imp / (1.25 * 2**(26 * (imp > (1.25 * (2**26))))), 2)) + 65) + str(int(self.getAverageForce()))
 
     def getFullDesignation(self):
         """Returns the full motor designation, which also includes the total impulse prepended on"""

--- a/uilib/converters/engExporter.py
+++ b/uilib/converters/engExporter.py
@@ -4,13 +4,14 @@ from motorlib.properties import PropertyCollection, FloatProperty, StringPropert
 from ..converter import Exporter
 
 from ..views.EngExporter_ui import Ui_EngExporterDialog
+from motorlib.constants import maximumRefDiameter, maximumRefLength
 
 class EngSettings(PropertyCollection):
     def __init__(self):
         super().__init__()
-        self.props['diameter'] = FloatProperty('Motor Diameter', 'm', 0, 1)
-        self.props['length'] = FloatProperty('Motor Length', 'm', 0, 4)
-        self.props['hardwareMass'] = FloatProperty('Hardware Mass', 'kg', 0, 1000)
+        self.props['diameter'] = FloatProperty('Motor Diameter', 'm', 0, maximumRefDiameter)
+        self.props['length'] = FloatProperty('Motor Length', 'm', 0, maximumRefLength)
+        self.props['hardwareMass'] = FloatProperty('Hardware Mass', 'kg', 0, 10000)
         self.props['designation'] = StringProperty('Motor Designation')
         self.props['manufacturer'] = StringProperty('Motor Manufacturer')
         self.props['append'] = EnumProperty('Existing File', ['Append', 'Overwrite'])

--- a/uilib/tools/changeDiameter.py
+++ b/uilib/tools/changeDiameter.py
@@ -1,11 +1,11 @@
 import motorlib
 
 from ..tool import Tool
-
+from motorlib.constants import maximumRefDiameter
 
 class ChangeDiameterTool(Tool):
     def __init__(self, manager):
-        props = {'diameter': motorlib.properties.FloatProperty('Diameter', 'm', 0, 1)}
+        props = {'diameter': motorlib.properties.FloatProperty('Diameter', 'm', 0, maximumRefDiameter)}
         super().__init__(manager,
                          'Motor Diameter',
                          'Use this tool to set the diameter of all grains in the motor.',

--- a/uilib/tools/neutralBates.py
+++ b/uilib/tools/neutralBates.py
@@ -1,13 +1,13 @@
 import motorlib
 
 from ..tool import Tool
-
+from motorlib.constants import maximumRefDiameter, maximumRefLength
 
 class NeutralBatesTool(Tool):
     def __init__(self, manager):
-        props = {'length': motorlib.properties.FloatProperty('Propellant length', 'm', 0, 10),
-                 'diameter': motorlib.properties.FloatProperty('Propellant diameter', 'm', 0, 1),
-                 'grainSpace': motorlib.properties.FloatProperty('Grain spacer length', 'm', 0, 1),
+        props = {'length': motorlib.properties.FloatProperty('Propellant length', 'm', 0, maximumRefLength),
+                 'diameter': motorlib.properties.FloatProperty('Propellant diameter', 'm', 0, maximumRefDiameter),
+                 'grainSpace': motorlib.properties.FloatProperty('Grain spacer length', 'm', 0, maximumRefLength/10),
                  'Kn': motorlib.properties.FloatProperty('Initial Kn', '', 1, 1000)}
 
         super().__init__(manager,


### PR DESCRIPTION
Added maximumRefLength and maximumRefDiameter which control the maximum user settable diameter and lengths across motorlib and uilib. Increased maximum motor diameter to 6.6 meter and grain length to 24.6 meters, if someone needs to simulate a motor larger than the [Aerojet 260](https://en.wikipedia.org/wiki/Aerojet_260) they will regrettably need to seek other ballistics software. 