### PR TITLE
Added RCS propellants to propellant library and made migration function

### DIFF
--- a/uilib/defaults.py
+++ b/uilib/defaults.py
@@ -208,4 +208,262 @@ KNSU_PROPS = {
             ]
 }
 
-DEFAULT_PROPELLANTS = [CL_PROPS, OW_PROPS, KNDX_PROPS, KNSB_PROPS, KNSU_PROPS, WL_PROPS, BT_PROPS]
+CL_PROPS = {
+            'name': 'MIT - Cherry Limeade',
+            'density': 1670, # kg/m^3
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 6.895e+06,
+                    'a': 3.517054143255937e-05,
+                    'n': 0.3273,
+                    't': 2800, 
+                    'm': 23.67,
+                    'k': 1.21
+                }
+            ]
+}
+
+WL_PROPS = {
+            'name': 'RCS - White Lightning',
+            'density': 1820.230534,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 5.71052e-05,
+                    'n': 0.45,
+                    't': 2339, 
+                    'm': 27.125,
+                    'k': 1.243
+                }
+            ]
+}
+
+BT_PROPS = {
+            'name': 'RCS - Blue Thunder',
+            'density': 1625.087206,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 6.994601e-05,
+                    'n': 0.321,
+                    't': 2616.532, 
+                    'm': 22.959,
+                    'k': 1.235
+                }
+            ]
+}
+
+BJ_PROPS = {
+            'name': 'RCS - Black Jack',
+            'density': 1729.99366130,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00002969528,
+                    'n': 0.36600000,
+                    't': 2238.589, 
+                    'm': 26.502,
+                    'k': 1.225
+                }
+            ]
+}
+
+R_PROPS = {
+            'name': 'RCS - Redline',
+            'density': 2085.95715705,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 1.23560472e-03,
+                    'n': 0.056,
+                    't': 1428.99, 
+                    'm': 30.561,
+                    'k': 1.247
+                }
+            ]
+}
+
+BM_PROPS = {
+            'name': 'RCS - Black Max',
+            'density': 2085.95715705,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 1.23560472e-03,
+                    'n': 0.056,
+                    't': 1428.99, 
+                    'm': 30.561,
+                    'k': 1.247
+                }
+            ]
+}
+
+WN_PROPS = {
+            'name': 'RCS - Warp 9',
+            'density': 2021.18619437,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00001507051,
+                    'n': 0.398,
+                    't': 1462.331, 
+                    'm': 27.627,
+                    'k': 1.275
+                }
+            ]
+}
+
+MG_PROPS = {
+            'name': 'RCS - Mojave Green',
+            'density': 1807.77417632,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00000813177,
+                    'n': 0.462,
+                    't': 2913.486, 
+                    'm': 29.784,
+                    'k': 1.209
+                }
+            ]
+}
+
+C_PROPS = {
+            'name': 'RCS - Classic',
+            'density': 1646.95396556,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00004444896,
+                    'n': 0.323,
+                    't': 2887.981, 
+                    'm': 24.145,
+                    'k': 1.225
+                }
+            ]
+}
+
+M_PROPS = {
+            'name': 'RCS - Metalstorm',
+            'density': 1819.39973372,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00000571052,
+                    'n': 0.45,
+                    't': 2558.168, 
+                    'm': 29.153,
+                    'k': 1.21
+                }
+            ]
+}
+
+MD_PROPS = {
+            'name': 'RCS - Metalstorm DM',
+            'density': 1697.88497895,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00004643358,
+                    'n': 0.334,
+                    't': 1895.29, 
+                    'm': 23.262,
+                    'k': 1.257
+                }
+            ]
+}
+
+PX_PROPS = {
+            'name': 'RCS - Propellant X (K1103X)',
+            'density': 1746.60160045,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00004614321,
+                    'n': 0.358,
+                    't': 3442.461, 
+                    'm': 27.704,
+                    'k': 1.177
+                }
+            ]
+}
+
+ST_PROPS = {
+            'name': 'RCS - Super Thunder',
+            'density': 1644.18597570,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00027247858,
+                    'n': 0.277,
+                    't': 2737.657, 
+                    'm': 23.767,
+                    'k': 1.223
+                }
+            ]
+}
+
+SWL_PROPS = {
+            'name': 'RCS - Slow White Lightning',
+            'density': 1815.80134690,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00002147703,
+                    'n': 0.346,
+                    't': 2364.133, 
+                    'm': 27.022,
+                    'k': 1.245
+                }
+            ]
+}
+
+NBT_PROPS = {
+            'name': 'RCS - New Blue Thunder',
+            'density': 1702.59056171,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00001470602,
+                    'n': 0.410,
+                    't': 3184.414, 
+                    'm': 26.005,
+                    'k': 1.203
+                }
+            ]
+}
+
+SSWL_PROPS = {
+            'name': 'RCS - Slower White Lightning',
+            'density': 1815.80134690,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00007994681,
+                    'n': 0.244,
+                    't': 2364.133, 
+                    'm': 27.022,
+                    'k': 1.245
+                }
+            ]
+}
+
+
+DEFAULT_PROPELLANTS = [CL_PROPS, OW_PROPS, KNDX_PROPS, KNSB_PROPS, KNSU_PROPS, 
+                       WL_PROPS, BT_PROPS, BJ_PROPS, R_PROPS, BM_PROPS, WN_PROPS, MG_PROPS, C_PROPS, M_PROPS, MD_PROPS, PX_PROPS, ST_PROPS, SWL_PROPS, NBT_PROPS, SSWL_PROPS]

--- a/uilib/defaults.py
+++ b/uilib/defaults.py
@@ -207,105 +207,38 @@ KNSU_PROPS = {
                 }
             ]
 }
-
-CL_PROPS = {
-            'name': 'MIT - Cherry Limeade',
-            'density': 1670, # kg/m^3
-            'tabs': [
-                {
-                    'minPressure': 0,
-                    'maxPressure': 6.895e+06,
-                    'a': 3.517054143255937e-05,
-                    'n': 0.3273,
-                    't': 2800, 
-                    'm': 23.67,
-                    'k': 1.21
-                }
-            ]
-}
-
-WL_PROPS = {
-            'name': 'RCS - White Lightning',
-            'density': 1820.230534,
-            'tabs': [
-                {
-                    'minPressure': 0,
-                    'maxPressure': 10342500,
-                    'a': 5.71052e-05,
-                    'n': 0.45,
-                    't': 2339, 
-                    'm': 27.125,
-                    'k': 1.243
-                }
-            ]
-}
-
-BT_PROPS = {
-            'name': 'RCS - Blue Thunder',
-            'density': 1625.087206,
-            'tabs': [
-                {
-                    'minPressure': 0,
-                    'maxPressure': 10342500,
-                    'a': 6.994601e-05,
-                    'n': 0.321,
-                    't': 2616.532, 
-                    'm': 22.959,
-                    'k': 1.235
-                }
-            ]
-}
-
 BJ_PROPS = {
             'name': 'RCS - Black Jack',
+            'density': 2085.95715705,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00123560472,
+                    'n': 0.05600000,
+                    't': 1428.99, 
+                    'm': 30.561,
+                    'k': 1.247
+                }
+            ]
+}
+R_PROPS = {
+            'name': 'RCS - Redline',
             'density': 1729.99366130,
             'tabs': [
                 {
                     'minPressure': 0,
                     'maxPressure': 10342500,
                     'a': 0.00002969528,
-                    'n': 0.36600000,
+                    'n': 0.366,
                     't': 2238.589, 
                     'm': 26.502,
                     'k': 1.225
                 }
             ]
 }
-
-R_PROPS = {
-            'name': 'RCS - Redline',
-            'density': 2085.95715705,
-            'tabs': [
-                {
-                    'minPressure': 0,
-                    'maxPressure': 10342500,
-                    'a': 1.23560472e-03,
-                    'n': 0.056,
-                    't': 1428.99, 
-                    'm': 30.561,
-                    'k': 1.247
-                }
-            ]
-}
-
 BM_PROPS = {
             'name': 'RCS - Black Max',
-            'density': 2085.95715705,
-            'tabs': [
-                {
-                    'minPressure': 0,
-                    'maxPressure': 10342500,
-                    'a': 1.23560472e-03,
-                    'n': 0.056,
-                    't': 1428.99, 
-                    'm': 30.561,
-                    'k': 1.247
-                }
-            ]
-}
-
-WN_PROPS = {
-            'name': 'RCS - Warp 9',
             'density': 2021.18619437,
             'tabs': [
                 {
@@ -319,7 +252,21 @@ WN_PROPS = {
                 }
             ]
 }
-
+WN_PROPS = {
+            'name': 'RCS - Warp 9',
+            'density': 1641.41798584,
+            'tabs': [
+                {
+                    'minPressure': 0,
+                    'maxPressure': 10342500,
+                    'a': 0.00024721816,
+                    'n': 0.287,
+                    't': 2780.64, 
+                    'm': 23.669,
+                    'k': 1.229
+                }
+            ]
+}
 MG_PROPS = {
             'name': 'RCS - Mojave Green',
             'density': 1807.77417632,
@@ -335,7 +282,6 @@ MG_PROPS = {
                 }
             ]
 }
-
 C_PROPS = {
             'name': 'RCS - Classic',
             'density': 1646.95396556,
@@ -351,7 +297,6 @@ C_PROPS = {
                 }
             ]
 }
-
 M_PROPS = {
             'name': 'RCS - Metalstorm',
             'density': 1819.39973372,
@@ -367,7 +312,6 @@ M_PROPS = {
                 }
             ]
 }
-
 MD_PROPS = {
             'name': 'RCS - Metalstorm DM',
             'density': 1697.88497895,
@@ -383,7 +327,6 @@ MD_PROPS = {
                 }
             ]
 }
-
 PX_PROPS = {
             'name': 'RCS - Propellant X (K1103X)',
             'density': 1746.60160045,
@@ -399,7 +342,6 @@ PX_PROPS = {
                 }
             ]
 }
-
 ST_PROPS = {
             'name': 'RCS - Super Thunder',
             'density': 1644.18597570,
@@ -415,7 +357,6 @@ ST_PROPS = {
                 }
             ]
 }
-
 SWL_PROPS = {
             'name': 'RCS - Slow White Lightning',
             'density': 1815.80134690,
@@ -431,7 +372,6 @@ SWL_PROPS = {
                 }
             ]
 }
-
 NBT_PROPS = {
             'name': 'RCS - New Blue Thunder',
             'density': 1702.59056171,
@@ -447,7 +387,6 @@ NBT_PROPS = {
                 }
             ]
 }
-
 SSWL_PROPS = {
             'name': 'RCS - Slower White Lightning',
             'density': 1815.80134690,

--- a/uilib/fileIO.py
+++ b/uilib/fileIO.py
@@ -8,7 +8,7 @@ import platformdirs
 from .defaults import DEFAULT_PREFERENCES, DEFAULT_PROPELLANTS, KNSU_PROPS
 from .logger import logger
 
-appVersion = (0, 6, 1)
+appVersion = (0, 6, 2)
 appVersionStr = '.'.join(map(str, appVersion))
 
 class fileTypes(Enum):
@@ -65,6 +65,14 @@ def getConfigPath():
     return '{}/'.format(path)
 
 def passthrough(data):
+    return data
+
+# 0.6.1 to 0.6.2
+def migrateProp_0_6_1_to_0_6_2(data):
+    # Add RCS propellants to library
+    for propellant in DEFAULT_PROPELLANTS:
+        if propellant['name'] not in [cProp['name'] for cProp in data]:
+            data.append(propellant)
     return data
     
 #0.6.0 to 0.6.1
@@ -170,6 +178,13 @@ def migrateMotor_0_2_0_to_0_3_0(data):
     return data
 
 migrations = {
+    (0, 6, 1): {
+        'to': (0, 6, 2),
+        fileTypes.PREFERENCES: passthrough,
+        fileTypes.PROPELLANTS: migrateProp_0_6_1_to_0_6_2,
+        fileTypes.MOTOR: passthrough,
+        fileTypes.RECENT_FILES: passthrough
+    },
     (0, 6, 0): {
         'to': (0, 6, 1),
         fileTypes.PREFERENCES: passthrough,


### PR DESCRIPTION
Added propellant data for all AeroTech propellants from the [RCS website](https://www.rocketmotorparts.com/browse/cat1577810_1952798.aspx) and created a migration function to add the new propellants to users' libraries when upgrading from 0.6.1 to 0.6.2