### PR TITLE
Note Python 3.11 workaround for missing prebuilt wheels in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ $ python setup.py build_ui
 ```
 Note that if you make changes to the UI using the `.ui` forms, you must re-build using the same command.
 
+###### Note: `build_ui` depends on `pyqt-distutils`, which still imports the deprecated `pkg_resources` module. Recent versions of `setuptools` (81+) removed it, so `setup.py build_ui` will silently report "pyqt_distutils not found, build_ui command will be unavailable" and fail with `error: invalid command 'build_ui'`. If you hit this, run `pip install "setuptools<81"` first.
+
+Skipping this step (or the Cython step below) will make `python main.py` fail at import time, e.g. `ModuleNotFoundError: No module named 'mathlib._find_perimeter_cy'` or errors importing `uilib.views.MainWindow_ui`.
+
 #### Cython Files:
 to speed up some more computationally expensive parts of the codebase, openMotor uses the Cython programming language to run calculations in C.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ skfmm/fmm.cpp:4:10: fatal error: Python.h: No such file or directory
 ```
 The fix is to install `python3-dev` or the equivalent with your system package manager.
 
+###### Note: The versions pinned in `requirements.txt` (numpy, scipy, scikit-fmm, etc.) do not have prebuilt wheels for very new Python releases (e.g. 3.13), which causes `pip install -r requirements.txt` to fail while building from source. If you hit this, create the venv with Python 3.11 instead (e.g. `python3.11 -m venv .venv`, installed via `brew install python@3.11` on Mac or your system package manager elsewhere).
+
 If you are running Windows and get errors like `DLL load failed while importing _cext` when trying to run the application after installing the dependencies, you may need to install the latest Microsoft Visual C++ Redistributable.
 
 #### UI Files:


### PR DESCRIPTION
## Summary
- On newer Python releases (e.g. 3.13), the versions pinned in `requirements.txt` (numpy, scipy, scikit-fmm, etc.) have no prebuilt wheels, so `pip install -r requirements.txt` fails while trying to build from source.
- Adds a note to the Building from Source section pointing to Python 3.11 as a working alternative.

## Test plan
- [x] Verified the failure on Python 3.13 (`BackendUnavailable: Cannot import 'setuptools.build_meta'`)
- [x] Verified `pip install -r requirements.txt` succeeds cleanly on Python 3.11
- [x] Verified `python main.py` launches successfully on Python 3.11