### PR TITLE
feat: Simulation alert enumeration cleanup

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,8 +7,7 @@ from PyQt6.QtWidgets import QApplication, QMessageBox
 from PyQt6.QtGui import QIcon
 from PyQt6.QtCore import Qt
 
-import motorlib
-from motorlib import simResult
+
 from uilib import preferencesManager, propellantManager, simulationManager, fileManager, toolManager
 from uilib import importExportManager
 import uilib.widgets.mainWindow
@@ -61,8 +60,9 @@ class App(QApplication):
                 motor = self.fileManager.getCurrentMotor()
                 simulationResult = motor.runSimulation()
                 for alert in simulationResult.alerts:
-                    print('{} ({}, {}): {}'.format(motorlib.simResult.alertLevelNames[alert.level],
-                        motorlib.simResult.alertTypeNames[alert.type],
+                    print('{} ({}, {}): {}'.format(
+                        alert.level.name.capitalize(),
+                        alert.type.name.capitalize(),
                         alert.location,
                         alert.description))
                 print()

--- a/motorlib/simResult.py
+++ b/motorlib/simResult.py
@@ -26,19 +26,6 @@ class SimAlertType(Enum):
     VALUE = 3
 
 
-alertLevelNames = {
-    SimAlertLevel.ERROR: "Error",
-    SimAlertLevel.WARNING: "Warning",
-    SimAlertLevel.MESSAGE: "Message",
-}
-
-alertTypeNames = {
-    SimAlertType.GEOMETRY: "Geometry",
-    SimAlertType.CONSTRAINT: "Constraint",
-    SimAlertType.VALUE: "Value",
-}
-
-
 class SimAlert:
     """A sim alert signifies a possible problem with a motor. It has levels of severity including 'error' (simulation
     should not continue or has failed), 'warning' (values entered appear incorrect but can be simulated), and 'message'

--- a/uilib/widgets/resultsWidget.py
+++ b/uilib/widgets/resultsWidget.py
@@ -2,7 +2,7 @@ from PyQt6.QtWidgets import QWidget, QHeaderView, QLabel, QTableWidgetItem
 import numpy as np
 
 import motorlib
-from motorlib.simResult import singleValueChannels, multiValueChannels, alertLevelNames, alertTypeNames
+from motorlib.simResult import singleValueChannels, multiValueChannels
 from motorlib.constants import standardGravity
 
 from .grainImageWidget import GrainImageWidget
@@ -84,8 +84,8 @@ class ResultsWidget(QWidget):
         self.ui.tableWidgetAlerts.setRowCount(0) # Clear the table
         self.ui.tableWidgetAlerts.setRowCount(len(simResult.alerts))
         for row, alert in enumerate(simResult.alerts):
-            self.ui.tableWidgetAlerts.setItem(row, 0, QTableWidgetItem(alertLevelNames[alert.level]))
-            self.ui.tableWidgetAlerts.setItem(row, 1, QTableWidgetItem(alertTypeNames[alert.type]))
+            self.ui.tableWidgetAlerts.setItem(row, 0, QTableWidgetItem(alert.level.name.capitalize()))
+            self.ui.tableWidgetAlerts.setItem(row, 1, QTableWidgetItem(alert.type.name.capitalize()))
             self.ui.tableWidgetAlerts.setItem(row, 2, QTableWidgetItem(alert.location))
             self.ui.tableWidgetAlerts.setItem(row, 3, QTableWidgetItem(alert.description))
 

--- a/uilib/widgets/simulationAlertsDialog.py
+++ b/uilib/widgets/simulationAlertsDialog.py
@@ -1,7 +1,5 @@
 from PyQt6.QtWidgets import QDialog, QTableWidgetItem, QHeaderView, QApplication
 
-from motorlib.simResult import alertLevelNames, alertTypeNames
-
 from ..views.SimulationAlertsDialog_ui import Ui_SimAlertsDialog
 
 class SimulationAlertsDialog(QDialog):
@@ -27,8 +25,8 @@ class SimulationAlertsDialog(QDialog):
 
         self.ui.tableWidgetAlerts.setRowCount(len(simRes.alerts))
         for row, alert in enumerate(simRes.alerts):
-            self.ui.tableWidgetAlerts.setItem(row, 0, QTableWidgetItem(alertLevelNames[alert.level]))
-            self.ui.tableWidgetAlerts.setItem(row, 1, QTableWidgetItem(alertTypeNames[alert.type]))
+            self.ui.tableWidgetAlerts.setItem(row, 0, QTableWidgetItem(alert.level.name.capitalize()))
+            self.ui.tableWidgetAlerts.setItem(row, 1, QTableWidgetItem(alert.type.name.capitalize()))
             self.ui.tableWidgetAlerts.setItem(row, 2, QTableWidgetItem(alert.location))
             self.ui.tableWidgetAlerts.setItem(row, 3, QTableWidgetItem(alert.description))
         self.show()


### PR DESCRIPTION
Just a small code cleanup.

Since Python Enums already store names and values, we can remove the extra mapping to simplify the code.

Relevant [documentation](https://docs.python.org/3/library/enum.html#enum.Enum)